### PR TITLE
Change alignment of profile and version to LEADING

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/views/MainPagePanel.form
+++ b/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/views/MainPagePanel.form
@@ -39,7 +39,7 @@
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="pnlPassword" alignment="1" max="32767" attributes="0"/>
                       <Group type="102" alignment="0" attributes="0">
-                          <Group type="103" groupAlignment="1" attributes="0">
+                          <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="jLabel10" alignment="1" min="-2" max="-2" attributes="0"/>
                               <Component id="jLabel1" alignment="1" min="-2" max="-2" attributes="0"/>
                           </Group>

--- a/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/views/MainPagePanel.java
+++ b/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/views/MainPagePanel.java
@@ -237,7 +237,7 @@ public class MainPagePanel extends javax.swing.JPanel {
                 .addGroup(pnlMoreLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(pnlPassword, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addGroup(pnlMoreLayout.createSequentialGroup()
-                        .addGroup(pnlMoreLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                        .addGroup(pnlMoreLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(jLabel10)
                             .addComponent(jLabel1))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)


### PR DESCRIPTION
Just because I cannot bear the previous alignment. :3

Before:

	 Profile|
	|Version|
	|Login
	|Name

![before](https://cloud.githubusercontent.com/assets/5229241/8390388/9d995886-1cc3-11e5-81a4-898fd0e13e75.png)

After:

	|Profile
	|Version
	|Login
	|Name

![after](https://cloud.githubusercontent.com/assets/5229241/8390389/9dc75024-1cc3-11e5-9b74-653891fbf95b.png)

p.s. I don't have Swing Plugin, so I edit `MainPagePanel.form` myself. Also, I haven't tested Chinese version yet, but it should work fine.