### PR TITLE
在 Windows 的启动脚本里增加一行 cd %appdata%

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/core/launch/GameLauncher.java
+++ b/HMCL/src/main/java/org/jackhuang/hellominecraft/launcher/core/launch/GameLauncher.java
@@ -174,6 +174,8 @@ public class GameLauncher {
             if (appdata != null) {
                 writer.write("set appdata=" + appdata);
                 writer.newLine();
+                writer.write("cd %appdata%");
+                writer.newLine();
             }
         }
         if (StrUtils.isNotBlank(options.getPrecalledCommand())) {


### PR DESCRIPTION
这样可以避免一些文件如 logs 生成在脚本所在目录，而不是 .minecraft 目录