### PR TITLE
Windows 启动脚本中允许跨分区 cd

### DIFF
--- a/HMCL/src/core/java/org/jackhuang/hellominecraft/launcher/core/launch/GameLauncher.java
+++ b/HMCL/src/core/java/org/jackhuang/hellominecraft/launcher/core/launch/GameLauncher.java
@@ -175,7 +175,7 @@ public class GameLauncher {
             if (appdata != null) {
                 writer.write("set appdata=" + appdata);
                 writer.newLine();
-                writer.write("cd %appdata%");
+                writer.write("cd /D %appdata%");
                 writer.newLine();
             }
         }


### PR DESCRIPTION
修复跨分区的情况下一些文件如 logs 仍然生成在脚本所在目录，而不是 .minecraft 目录

/D 的作用可以在 cmd 内输入 cd /? 来查看
D 必须为大写