### PR TITLE
Mac下日志及配置文件位置的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -101,7 +101,11 @@ public final class Main {
     public static void main(String[] args) throws IOException {
         {
             try {
-                File file = new File("hmcl.log").getAbsoluteFile();
+                File file = new File("/Users/rhj/.hmcl/hmcl.log").getAbsoluteFile();
+                LOGGER.log(Level.WARNING, "地址", file);
+                File parent = file.getParentFile();
+                if (!parent.exists() && !parent.mkdirs())
+                    LOGGER.log(Level.WARNING, "Failed to create log file parent {0}", parent);
                 if (!file.exists() && !file.createNewFile())
                     LOGGER.log(Level.WARNING, "Failed to create log file {0}", file);
                 Configuration.DEFAULT.appenders.add(new ConsoleAppender("File", new DefaultLayout(), true, new FileOutputStream(file), true));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -101,8 +101,7 @@ public final class Main {
     public static void main(String[] args) throws IOException {
         {
             try {
-                File file = new File("/Users/rhj/.hmcl/hmcl.log").getAbsoluteFile();
-                LOGGER.log(Level.WARNING, "地址", file);
+                File file = new File(".hmcl/hmcl.log").getAbsoluteFile();
                 File parent = file.getParentFile();
                 if (!parent.exists() && !parent.mkdirs())
                     LOGGER.log(Level.WARNING, "Failed to create log file parent {0}", parent);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -45,7 +45,7 @@ public final class Settings {
     public static final String DEFAULT_PROFILE = "Default";
     public static final String HOME_PROFILE = "Home";
 
-    public static final File SETTINGS_FILE = new File("/Users/rhj/.hmcl/hmcl.json").getAbsoluteFile();
+    public static final File SETTINGS_FILE = new File(".hmcl/hmcl.json").getAbsoluteFile();
 
     private static final Config SETTINGS;
     public static final UpdateChecker UPDATE_CHECKER = new UpdateChecker(HMCLApi.HMCL_VERSION, "hmcl");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -45,7 +45,7 @@ public final class Settings {
     public static final String DEFAULT_PROFILE = "Default";
     public static final String HOME_PROFILE = "Home";
 
-    public static final File SETTINGS_FILE = new File("hmcl.json").getAbsoluteFile();
+    public static final File SETTINGS_FILE = new File("/Users/rhj/.hmcl/hmcl.json").getAbsoluteFile();
 
     private static final Config SETTINGS;
     public static final UpdateChecker UPDATE_CHECKER = new UpdateChecker(HMCLApi.HMCL_VERSION, "hmcl");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/modpack/ModpackWizard.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/modpack/ModpackWizard.java
@@ -119,7 +119,7 @@ public class ModpackWizard extends WizardBranchController {
                                     if (!IOUtils.isAbsolutePath(Settings.getInstance().getBgpath()))
                                         s.setBgpath(Settings.getInstance().getBgpath());
                                     s.setDownloadType(Settings.getInstance().getDownloadType());
-                                    engine.putTextFile(C.GSON.toJson(s), "/Users/rhj/.hmcl/hmcl.json");
+                                    engine.putTextFile(C.GSON.toJson(s), ".hmcl/hmcl.json");
                                     engine.putFile(modpack, "modpack.zip");
                                     File bg = new File("bg").getAbsoluteFile();
                                     if (bg.isDirectory())

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/modpack/ModpackWizard.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/modpack/ModpackWizard.java
@@ -119,7 +119,7 @@ public class ModpackWizard extends WizardBranchController {
                                     if (!IOUtils.isAbsolutePath(Settings.getInstance().getBgpath()))
                                         s.setBgpath(Settings.getInstance().getBgpath());
                                     s.setDownloadType(Settings.getInstance().getDownloadType());
-                                    engine.putTextFile(C.GSON.toJson(s), "hmcl.json");
+                                    engine.putTextFile(C.GSON.toJson(s), "/Users/rhj/.hmcl/hmcl.json");
                                     engine.putFile(modpack, "modpack.zip");
                                     File bg = new File("bg").getAbsoluteFile();
                                     if (bg.isDirectory())


### PR DESCRIPTION
Mac 下这些文件默认会创建在 **/Users/xxx/** 目录下面，这样感觉会污染用户目录，建议创建一个.hmcl 目录，然后将配置文件扔进去。
我这边无论是 IDEA 还是 Netbeans 都无法成功导入项目😂，所以只是用 VSCode 简单修改了一下，建议你针对不同平台做一下不同配置。