### PR TITLE
partial rv 7fe3e28a, fixes Forge on 1.12

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/HMCLMinecraftLoader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/HMCLMinecraftLoader.java
@@ -41,11 +41,5 @@ public class HMCLMinecraftLoader extends MinecraftLoader {
         
         list.add("-Dminecraft.launcher.version=" + Main.LAUNCHER_VERSION);
         list.add("-Dminecraft.launcher.brand=" + Main.LAUNCHER_NAME);
-        
-        boolean flag = false;
-        for (String s : list) if (s.contains("-Dlog4j.configurationFile=")) flag = true;
-        if (!flag) {
-            list.add("-Dlog4j.configurationFile=" + Main.LOG4J_FILE.getAbsolutePath());
-        }
     }
 }


### PR DESCRIPTION
Forge 1.12.x does not like the log4j.xml provided by HMCL.