### PR TITLE
Set a custom User-Agent, fixes optifine.net downloads

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/net/NetUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/net/NetUtils.java
@@ -40,6 +40,7 @@ public final class NetUtils {
 
     public static HttpURLConnection createConnection(URL url, Proxy proxy) throws IOException {
         HttpURLConnection con = (HttpURLConnection) url.openConnection(proxy);
+        con.setRequestProperty("User-Agent", "Hello Minecraft!");
         con.setDoInput(true);
         con.setUseCaches(false);
         con.setConnectTimeout(15000);
@@ -48,7 +49,9 @@ public final class NetUtils {
     }
 
     public static String get(String url, String encoding) throws IOException {
-        return IOUtils.toString(new URL(url).openConnection().getInputStream());
+        HttpURLConnection con = (HttpURLConnection) new URL(url).openConnection();
+        con.setRequestProperty("User-Agent", "Hello Minecraft!");
+        return IOUtils.toString(con.getInputStream());
     }
 
     public static String get(String url) throws IOException {


### PR DESCRIPTION
OptiFine is blocking access from User-Agents beginning with "Java/1."