### PR TITLE
Fixed invalid forge download url

### DIFF
--- a/HMCLCore/src/main/kotlin/org/jackhuang/hmcl/download/MojangDownloadProvider.kt
+++ b/HMCLCore/src/main/kotlin/org/jackhuang/hmcl/download/MojangDownloadProvider.kt
@@ -44,7 +44,7 @@ object MojangDownloadProvider : DownloadProvider() {
     }
 
     override fun injectURL(baseURL: String): String {
-        if (baseURL.endsWith("net/minecraftforge/forge/json"))
+        if (baseURL.contains("net/minecraftforge/forge"))
             return baseURL
         else
             return baseURL.replace("http://files.minecraftforge.net/maven", "http://ftb.cursecdn.com/FTB2/maven")


### PR DESCRIPTION
Fixed invalid forge download url

     [10:46:20] [org.jackhuang.hmcl.task.FileDownloadTask.execute/WARNING] Unable to download file http://ftb.cursecdn.com/FTB2/maven/net/minecraftforge/forge/1.7.10-10.13.4.1614-1.7.10/forge-1.7.10-10.13.4.1614-1.7.10-installer.jar
     java.io.IOException: Server error, response code: 404
         at org.jackhuang.hmcl.task.FileDownloadTask.execute(FileDownloadTask.kt:88)
         at org.jackhuang.hmcl.task.TaskExecutor.executeTask(TaskExecutor.kt:117)
         at org.jackhuang.hmcl.task.TaskExecutor.access$executeTask(TaskExecutor.kt:30)
         at org.jackhuang.hmcl.task.TaskExecutor$Invoker.call(TaskExecutor.kt:158)
         at org.jackhuang.hmcl.task.TaskExecutor$Invoker.call(TaskExecutor.kt:154)
         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
         at java.lang.Thread.run(Thread.java:745)