### PR TITLE
对 OpenJDK 更好的支持

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -17,24 +17,42 @@
  */
 package org.jackhuang.hmcl;
 
-import org.jackhuang.hmcl.util.Logging;
-
-import javax.swing.*;
 import java.io.File;
+
+import javax.swing.JOptionPane;
 
 public final class Main {
 
     public static void main(String[] args) {
+        checkJavaFX();
+        checkDirectoryPath();
+        Launcher.main(args);
+    }
+
+    private static void checkDirectoryPath() {
         String currentDirectory = new File("").getAbsolutePath();
         if (currentDirectory.contains("!")) {
-            System.err.println("Exclamation mark(!) is not allowed in the path where HMCL is in. Forcibly exit.");
-
             // No Chinese translation because both Swing and JavaFX cannot render Chinese character properly when exclamation mark exists in the path.
-            String message = "Exclamation mark(!) is not allowed in the path where HMCL is in.\nThe path is " + currentDirectory;
-            JOptionPane.showMessageDialog(null, message, "Error", JOptionPane.ERROR_MESSAGE);
-            System.exit(1);
-        } else
-            Launcher.main(args);
+            showErrorAndExit("Exclamation mark(!) is not allowed in the path where HMCL is in.\n"
+                    + "The path is " + currentDirectory);
+        }
+    }
+
+    private static void checkJavaFX() {
+        try {
+            Class.forName("javafx.application.Application");
+        } catch (ClassNotFoundException e) {
+            showErrorAndExit("JavaFX is missing.\n"
+                    + "If you are using Java 11 or above, please downgrade to Java 8 or 10.\n"
+                    + "If you are using OpenJDK, please ensure OpenJFX is included.");
+        }
+    }
+
+    private static void showErrorAndExit(String message) {
+        System.err.println(message);
+        System.err.println("A fatal error has occurred, forcibly exiting.");
+        JOptionPane.showMessageDialog(null, message, "Error", JOptionPane.ERROR_MESSAGE);
+        System.exit(1);
     }
 
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/CrashReporter.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/CrashReporter.java
@@ -95,7 +95,7 @@ public class CrashReporter implements Thread.UncaughtExceptionHandler {
 
             Logging.LOG.log(Level.SEVERE, text);
 
-            if (checkThrowable(e) && !text.contains("OpenJDK")) {
+            if (checkThrowable(e)) {
                 Platform.runLater(() -> new CrashWindow(text).show());
                 if (!Launcher.UPDATE_CHECKER.isOutOfDate())
                     reportToServer(text);

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -107,7 +107,6 @@ crash.advice.no=No advice.
 crash.advice.no_lwjgl=Maybe drivers caused problems.
 crash.advice.otherwise=Maybe mods caused problems.
 crash.error=Minecraft has crashed.
-crash.headless=If your OS is Linux, please use Oracle JDK instead of OpenJDK, or add "-Djava.awt.headless=false" JVM argument, or check if your Xserver works normally.
 crash.launcher=Launcher has crashed!
 crash.minecraft=Minecraft has crashed!
 crash.user_fault=Your OS or Java environment may not be properly installed resulting in crashing of this software, please check your Java Environment or your computer!
@@ -199,7 +198,6 @@ launcher.crash=Hello Minecraft! Launcher has crashed!
 launcher.crash_out_dated=Hello Minecraft! Launcher has crashed! Your launcher is outdated. Update it!
 launcher.exit_failed=Failed to shutdown.
 launcher.modpack=Documentations for modpacks.
-launcher.open_jdk=We have found that you started this application using OpenJDK, which will cause so many troubles drawing the UI. We suggest you using Oracle JDK instead.
 launcher.restart=Options will be in operations only if restart this app.
 launcher.tab.about=About
 launcher.tab.general=General

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -107,7 +107,6 @@ crash.advice.no=无建议。
 crash.advice.no_lwjgl=可能是游戏依赖库不完整或解压依赖库时出错。可以通过下载整合包解决问题。
 crash.advice.otherwise=可能是Mod或其他问题。
 crash.error=您的Minecraft崩溃了。
-crash.headless=如果您的操作系统是Linux，请注意不要使用OpenJDK，务必使用Oracle JDK，或尝试添加-Djava.awt.headless=false参数，或检查您的Xserver是否正常
 crash.launcher=启动器崩溃了！
 crash.minecraft=Minecraft崩溃了！请认真阅读建议。
 crash.user_fault=您的系统或Java环境可能安装不当导致本软件崩溃，请检查您的Java环境或您的电脑！可以尝试重新安装Java。
@@ -199,7 +198,6 @@ launcher.crash=Hello Minecraft!遇到了无法处理的错误，请复制下列�
 launcher.crash_out_dated=Hello Minecraft! Launcher遇到了无法处理的错误，已检测到您的启动器不是最新版本，请更新后再试！
 launcher.exit_failed=强制退出失败，可能是Forge 1.7.10及更高版本导致的，无法解决。
 launcher.modpack=整合包作者帮助
-launcher.open_jdk=我们发现您正在使用OpenJDK，这会导致很多界面问题，我们建议您更换Oracle JDK。
 launcher.restart=本界面选项需要重启本启动器生效
 launcher.tab.about=关于
 launcher.tab.general=通用


### PR DESCRIPTION
* 移除若是 OpenJDK 则不上传错误报告这一判定
  * HMCL 3 使用 JavaFX，不会再遇到 Swing 问题了
* 当 JavaFX 缺失时，弹窗提示
  * 考虑到 Java 11 及之前某些版本的 OpenJDK 不包含 OpenJFX（#179）