### PR TITLE
添加 hmcl.version.override 选项用于调试更新功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -152,7 +152,7 @@ public final class Launcher extends Application {
     public static final File HMCL_DIRECTORY = OperatingSystem.getWorkingDirectory("hmcl");
     public static final File LOG_DIRECTORY = new File(Launcher.HMCL_DIRECTORY, "logs");
 
-    public static final String VERSION = "@HELLO_MINECRAFT_LAUNCHER_VERSION_FOR_GRADLE_REPLACING@";
+    public static final String VERSION = System.getProperty("hmcl.version.override", "@HELLO_MINECRAFT_LAUNCHER_VERSION_FOR_GRADLE_REPLACING@");
     public static final String NAME = "HMCL";
     public static final String TITLE = NAME + " " + VERSION;
     public static final ResourceBundle RESOURCE_BUNDLE = Settings.INSTANCE.getLocale().getResourceBundle();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/AppDataUpgrader.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/AppDataUpgrader.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -49,7 +48,7 @@ import java.util.zip.GZIPInputStream;
  */
 public class AppDataUpgrader extends IUpgrader {
 
-    private void launchNewerVersion(List<String> args, File jar) throws IOException, ClassNotFoundException, NoSuchMethodException, SecurityException, InvocationTargetException, IllegalAccessException {
+    private void launchNewerVersion(List<String> args, File jar) throws IOException, ReflectiveOperationException {
         try (JarFile jarFile = new JarFile(jar)) {
             String mainClass = jarFile.getManifest().getMainAttributes().getValue("Main-Class");
             if (mainClass == null)
@@ -91,7 +90,7 @@ public class AppDataUpgrader extends IUpgrader {
                 }
             } catch (JsonParseException ex) {
                 f.delete();
-            } catch (IOException | NoSuchMethodException | SecurityException | InvocationTargetException | IllegalAccessException | ClassNotFoundException t) {
+            } catch (IOException | ReflectiveOperationException t) {
                 Logging.LOG.log(Level.SEVERE, "Unable to execute newer version application", t);
                 AppDataUpgraderPackGzTask.HMCL_VER_FILE.delete(); // delete version json, let HMCL re-download the newer version.
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
@@ -27,9 +27,10 @@ import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.task.TaskResult;
 import org.jackhuang.hmcl.ui.construct.MessageBox;
 import org.jackhuang.hmcl.util.Constants;
-import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.NetworkUtils;
 import org.jackhuang.hmcl.util.VersionNumber;
+
+import static org.jackhuang.hmcl.util.Logging.LOG;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -78,8 +79,10 @@ public final class UpdateChecker {
 
             @Override
             public void execute() throws Exception {
-                if (isDevelopmentVersion(Launcher.VERSION))
+                if (isDevelopmentVersion(Launcher.VERSION)) {
+                    LOG.info("Current version is a development version, skip updating");
                     return;
+                }
 
                 if (value == null) {
                     versionString = http.getResult();
@@ -87,7 +90,7 @@ public final class UpdateChecker {
                 }
 
                 if (value == null) {
-                    Logging.LOG.warning("Unable to check update...");
+                    LOG.warning("Unable to check update...");
                     if (showMessage)
                         MessageBox.show(Launcher.i18n("update.failed"));
                 } else if (base.compareTo(value) < 0)
@@ -129,12 +132,13 @@ public final class UpdateChecker {
         return new TaskResult<Map<String, String>>() {
             @Override
             public void execute() {
-                if (download_link == null)
+                if (download_link == null) {
                     try {
                         download_link = Constants.GSON.<Map<String, String>>fromJson(NetworkUtils.doGet(NetworkUtils.toURL(Launcher.UPDATE_SERVER + "/hmcl/update_link.php")), Map.class);
                     } catch (JsonSyntaxException | IOException e) {
-                        Logging.LOG.log(Level.SEVERE, "Failed to get update link.", e);
+                        LOG.log(Level.SEVERE, "Failed to get update link.", e);
                     }
+                }
                 setResult(download_link);
             }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateChecker.java
@@ -78,7 +78,7 @@ public final class UpdateChecker {
 
             @Override
             public void execute() throws Exception {
-                if (Launcher.VERSION.contains("@"))
+                if (isDevelopmentVersion(Launcher.VERSION))
                     return;
 
                 if (value == null) {
@@ -101,6 +101,11 @@ public final class UpdateChecker {
                 return "update_checker.process";
             }
         };
+    }
+
+    private boolean isDevelopmentVersion(String version) {
+        return version.contains("@") || // eg. @HELLO_MINECRAFT_LAUNCHER_VERSION_FOR_GRADLE_REPLACING@
+                version.contains("SNAPSHOT"); // eg. 3.1.SNAPSHOT
     }
 
     /**


### PR DESCRIPTION
通过 `-Dhmcl.version.override=xxx` 指定 HMCL 版本。