### PR TITLE
修复有关 Yggdrasil 登录的一些 bug

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -22,6 +22,7 @@ import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.AuthInfo;
 import org.jackhuang.hmcl.auth.AuthenticationException;
+import org.jackhuang.hmcl.auth.CredentialExpiredException;
 import org.jackhuang.hmcl.auth.ServerDisconnectException;
 import org.jackhuang.hmcl.download.DefaultDependencyManager;
 import org.jackhuang.hmcl.download.MaintainTask;
@@ -106,14 +107,12 @@ public final class LauncherHelper {
                 .then(Task.of(Schedulers.javafx(), () -> emitStatus(LoadingState.LOGGING_IN)))
                 .then(Task.of(Launcher.i18n("account.methods"), variables -> {
                     try {
-                        try {
-                            variables.set("account", account.logIn());
-                        } catch (ServerDisconnectException e) {
-                            variables.set("account",
-                                    account.playOffline().orElseThrow(() -> e));
-                        }
-                    } catch (AuthenticationException e) {
+                        variables.set("account", account.logIn());
+                    } catch (CredentialExpiredException e) {
                         variables.set("account", DialogController.logIn(account));
+                    } catch (AuthenticationException e) {
+                        variables.set("account",
+                                account.playOffline().orElseThrow(() -> e));
                     }
                 }))
                 .then(Task.of(Schedulers.javafx(), () -> emitStatus(LoadingState.LAUNCHING)))

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
@@ -47,10 +47,9 @@ public abstract class Account {
     /**
      * Login with stored credentials.
      *
-     * @throws ServerDisconnectException if an network error has occurred, in which case password login won't be tried.
-     * @throws AuthenticationException if an error has occurred. If it's not a {@link ServerDisconnectException}, password login will be tried.
+     * @throws CredentialExpiredException when the stored credentials has expired, in which case a password login will be performed
      */
-    public abstract AuthInfo logIn() throws ServerDisconnectException, AuthenticationException;
+    public abstract AuthInfo logIn() throws CredentialExpiredException, AuthenticationException;
 
     /**
      * Login with specified password.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/CredentialExpiredException.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/CredentialExpiredException.java
@@ -1,0 +1,42 @@
+/*
+ * Hello Minecraft! Launcher.
+ * Copyright (C) 2018  huangyuhui <huanghongxun2008@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see {http://www.gnu.org/licenses/}.
+ */
+package org.jackhuang.hmcl.auth;
+
+/**
+ * Thrown when the stored credentials has expired.
+ * This exception indicates that a password login should be performed.
+ *
+ * @author yushijinhun
+ * @see Account#logIn()
+ */
+public class CredentialExpiredException extends AuthenticationException {
+
+    public CredentialExpiredException() {}
+
+    public CredentialExpiredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CredentialExpiredException(String message) {
+        super(message);
+    }
+
+    public CredentialExpiredException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/ServerResponseMalformedException.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/ServerResponseMalformedException.java
@@ -1,3 +1,20 @@
+/*
+ * Hello Minecraft! Launcher.
+ * Copyright (C) 2018  huangyuhui <huanghongxun2008@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see {http://www.gnu.org/licenses/}.
+ */
 package org.jackhuang.hmcl.auth;
 
 public class ServerResponseMalformedException extends AuthenticationException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilAccount.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilAccount.java
@@ -69,7 +69,15 @@ public class YggdrasilAccount extends Account {
             if (service.validate(session.getAccessToken(), session.getClientToken())) {
                 isOnline = true;
             } else {
-                updateSession(service.refresh(session.getAccessToken(), session.getClientToken(), null), new SpecificCharacterSelector(characterUUID));
+                try {
+                    updateSession(service.refresh(session.getAccessToken(), session.getClientToken(), null), new SpecificCharacterSelector(characterUUID));
+                } catch (RemoteAuthenticationException e) {
+                    if ("ForbiddenOperationException".equals(e.getRemoteName())) {
+                        throw new CredentialExpiredException(e);
+                    } else {
+                        throw e;
+                    }
+                }
             }
         }
         return session.toAuthInfo();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilAccount.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilAccount.java
@@ -66,40 +66,46 @@ public class YggdrasilAccount extends Account {
     @Override
     public AuthInfo logIn() throws AuthenticationException {
         if (!canPlayOnline()) {
-            logInWithToken();
-            selectProfile(new SpecificCharacterSelector(characterUUID));
+            if (service.validate(session.getAccessToken(), session.getClientToken())) {
+                isOnline = true;
+            } else {
+                updateSession(service.refresh(session.getAccessToken(), session.getClientToken(), null), new SpecificCharacterSelector(characterUUID));
+            }
         }
         return session.toAuthInfo();
     }
 
     @Override
-    public final AuthInfo logInWithPassword(String password) throws AuthenticationException {
+    public AuthInfo logInWithPassword(String password) throws AuthenticationException {
         return logInWithPassword(password, new SpecificCharacterSelector(characterUUID));
     }
 
     protected AuthInfo logInWithPassword(String password, CharacterSelector selector) throws AuthenticationException {
-        session = service.authenticate(username, password, UUIDTypeAdapter.fromUUID(UUID.randomUUID()));
-        selectProfile(selector);
+        updateSession(service.authenticate(username, password, UUIDTypeAdapter.fromUUID(UUID.randomUUID())), selector);
         return session.toAuthInfo();
     }
 
-    private void selectProfile(CharacterSelector selector) throws AuthenticationException {
-        if (session.getSelectedProfile() == null) {
-            if (session.getAvailableProfiles() == null || session.getAvailableProfiles().length <= 0)
+    /**
+     * Updates the current session. This method shall be invoked after authenticate/refresh operation.
+     * {@link #session} field shall be set only using this method. This method ensures {@link #session}
+     * has a profile selected.
+     *
+     * @param acquiredSession the session acquired by making an authenticate/refresh request
+     */
+    private void updateSession(YggdrasilSession acquiredSession, CharacterSelector selector) throws AuthenticationException {
+        if (acquiredSession.getSelectedProfile() == null) {
+            if (acquiredSession.getAvailableProfiles() == null || acquiredSession.getAvailableProfiles().length == 0)
                 throw new NoCharacterException(this);
 
-            session = service.refresh(session.getAccessToken(), session.getClientToken(), selector.select(this, Arrays.asList(session.getAvailableProfiles())));
+            this.session = service.refresh(
+                    acquiredSession.getAccessToken(),
+                    acquiredSession.getClientToken(),
+                    selector.select(this, Arrays.asList(acquiredSession.getAvailableProfiles())));
+        } else {
+            this.session = acquiredSession;
         }
 
-        characterUUID = session.getSelectedProfile().getId();
-    }
-
-    private void logInWithToken() throws AuthenticationException {
-        if (service.validate(session.getAccessToken(), session.getClientToken())) {
-            isOnline = true;
-            return;
-        }
-        session = service.refresh(session.getAccessToken(), session.getClientToken(), null);
+        this.characterUUID = this.session.getSelectedProfile().getId();
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilService.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilService.java
@@ -84,7 +84,10 @@ public class YggdrasilService {
             requireEmpty(request(provider.getValidationURL(), createRequestWithCredentials(accessToken, clientToken)));
             return true;
         } catch (RemoteAuthenticationException e) {
-            return false;
+            if ("ForbiddenOperationException".equals(e.getRemoteName())) {
+                return false;
+            }
+            throw e;
         }
     }
 


### PR DESCRIPTION
* 使用 `CredentialExpiredException` 而不是非 `ServerDisconnectException` 异常来指示需要进行密码登录
  * 在一些非凭证过期的情况下，也会抛出非 `ServerDisconnectException` 异常，如 authlib-injector 下载失败、服务器响应畸形
* 仅当选择角色成功时，才将登录信息写入 `YggdrasilAccount` 的 `session` 字段
  * 防止登录成功，但选择角色失败，造成 `YggdrasilAccount.session` 处于未选中角色的中间状态，引起 NPE
* 仅当 validate 操作返回 `ForbiddenOperationException` 异常时才认为 token 过期，而不是所有远程异常