### PR TITLE
Refactor(WIP) & Fixes

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -71,7 +71,7 @@ public final class Accounts {
     }
 
     private static AuthlibInjectorServer getOrCreateAuthlibInjectorServer(String url) {
-        return Settings.SETTINGS.authlibInjectorServers.stream()
+        return ConfigHolder.CONFIG.authlibInjectorServers.stream()
                 .filter(server -> url.equals(server.getUrl()))
                 .findFirst()
                 .orElseGet(() -> {
@@ -85,7 +85,7 @@ public final class Accounts {
                         LOG.log(Level.WARNING, "Failed to migrate authlib injector server " + url, e);
                     }
 
-                    Settings.SETTINGS.authlibInjectorServers.add(server);
+                    ConfigHolder.CONFIG.authlibInjectorServers.add(server);
                     return server;
                 });
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -17,12 +17,21 @@
  */
 package org.jackhuang.hmcl.setting;
 
+import java.io.File;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.hildan.fxgson.creators.ObservableListCreator;
+import org.hildan.fxgson.creators.ObservableMapCreator;
+import org.hildan.fxgson.creators.ObservableSetCreator;
+import org.hildan.fxgson.factories.JavaFxPropertyTypeAdapterFactory;
 import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
+import org.jackhuang.hmcl.util.FileTypeAdapter;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
 
 import javafx.beans.property.BooleanProperty;
@@ -36,8 +45,24 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
+import javafx.collections.ObservableSet;
 
 public final class Config implements Cloneable {
+
+    private static final Gson CONFIG_GSON = new GsonBuilder()
+            .registerTypeAdapter(VersionSetting.class, VersionSetting.Serializer.INSTANCE)
+            .registerTypeAdapter(Profile.class, Profile.Serializer.INSTANCE)
+            .registerTypeAdapter(File.class, FileTypeAdapter.INSTANCE)
+            .registerTypeAdapter(ObservableList.class, new ObservableListCreator())
+            .registerTypeAdapter(ObservableSet.class, new ObservableSetCreator())
+            .registerTypeAdapter(ObservableMap.class, new ObservableMapCreator())
+            .registerTypeAdapterFactory(new JavaFxPropertyTypeAdapterFactory(true, true))
+            .setPrettyPrinting()
+            .create();
+
+    public static Config fromJson(String json) throws JsonParseException {
+        return CONFIG_GSON.fromJson(json, Config.class);
+    }
 
     @SerializedName("last")
     public final StringProperty selectedProfile = new SimpleStringProperty("");
@@ -104,8 +129,12 @@ public final class Config implements Cloneable {
 
     public final ObservableList<AuthlibInjectorServer> authlibInjectorServers = FXCollections.observableArrayList();
 
+    public String toJson() {
+        return CONFIG_GSON.toJson(this);
+    }
+
     @Override
     public Config clone() {
-        return Settings.GSON.fromJson(Settings.GSON.toJson(this), Config.class);
+        return fromJson(this.toJson());
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -1,0 +1,65 @@
+/*
+ * Hello Minecraft! Launcher.
+ * Copyright (C) 2018  huangyuhui <huanghongxun2008@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see {http://www.gnu.org/licenses/}.
+ */
+package org.jackhuang.hmcl.setting;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.jackhuang.hmcl.util.Logging.LOG;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+
+import com.google.gson.JsonParseException;
+
+public final class ConfigHolder {
+
+    private ConfigHolder() {}
+
+    public static final String CONFIG_FILENAME = "hmcl.json";
+    public static final Path CONFIG_PATH = Paths.get(CONFIG_FILENAME).toAbsolutePath();
+    public static final Config CONFIG = initSettings();
+
+    private static Config initSettings() {
+        Config config = new Config();
+        if (Files.exists(CONFIG_PATH)) {
+            try {
+                Config deserialized = Config.fromJson(new String(Files.readAllBytes(CONFIG_PATH), UTF_8));
+                if (deserialized == null) {
+                    LOG.finer("Settings file is empty, use the default settings.");
+                } else {
+                    config = deserialized;
+                }
+                LOG.finest("Initialized settings.");
+            } catch (IOException | JsonParseException e) {
+                LOG.log(Level.WARNING, "Something happened wrongly when load settings.", e);
+            }
+        }
+        return config;
+    }
+
+    static void saveConfig(Config config) {
+        try {
+            Files.write(CONFIG_PATH, config.toJson().getBytes(UTF_8));
+        } catch (IOException ex) {
+            LOG.log(Level.SEVERE, "Failed to save config", ex);
+        }
+    }
+
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -17,21 +17,11 @@
  */
 package org.jackhuang.hmcl.setting;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
-import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
-import javafx.collections.ObservableSet;
 import javafx.scene.text.Font;
 
-import org.hildan.fxgson.creators.ObservableListCreator;
-import org.hildan.fxgson.creators.ObservableMapCreator;
-import org.hildan.fxgson.creators.ObservableSetCreator;
-import org.hildan.fxgson.factories.JavaFxPropertyTypeAdapterFactory;
 import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.AccountFactory;
@@ -60,16 +50,6 @@ import static org.jackhuang.hmcl.util.Lang.tryCast;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public class Settings {
-    public static final Gson GSON = new GsonBuilder()
-            .registerTypeAdapter(VersionSetting.class, VersionSetting.Serializer.INSTANCE)
-            .registerTypeAdapter(Profile.class, Profile.Serializer.INSTANCE)
-            .registerTypeAdapter(File.class, FileTypeAdapter.INSTANCE)
-            .registerTypeAdapter(ObservableList.class, new ObservableListCreator())
-            .registerTypeAdapter(ObservableSet.class, new ObservableSetCreator())
-            .registerTypeAdapter(ObservableMap.class, new ObservableMapCreator())
-            .registerTypeAdapterFactory(new JavaFxPropertyTypeAdapterFactory(true, true))
-            .setPrettyPrinting()
-            .create();
 
     public static final String SETTINGS_FILE_NAME = "hmcl.json";
     public static final File SETTINGS_FILE = new File(SETTINGS_FILE_NAME).getAbsoluteFile();
@@ -131,7 +111,7 @@ public class Settings {
                 if (StringUtils.isBlank(str))
                     Logging.LOG.finer("Settings file is empty, use the default settings.");
                 else {
-                    Config d = GSON.fromJson(str, Config.class);
+                    Config d = Config.fromJson(str);
                     if (d != null)
                         c = d;
                 }
@@ -152,7 +132,7 @@ public class Settings {
                 SETTINGS.accounts.add(storage);
             }
 
-            FileUtils.writeText(SETTINGS_FILE, GSON.toJson(SETTINGS));
+            FileUtils.writeText(SETTINGS_FILE, SETTINGS.toJson());
         } catch (IOException ex) {
             Logging.LOG.log(Level.SEVERE, "Failed to save config", ex);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
@@ -41,6 +41,7 @@ import org.jackhuang.hmcl.auth.yggdrasil.RemoteAuthenticationException;
 import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilAccount;
 import org.jackhuang.hmcl.game.AccountHelper;
 import org.jackhuang.hmcl.setting.Accounts;
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.Settings;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
@@ -80,7 +81,7 @@ public class AddAccountPane extends StackPane {
 
         cboServers.setCellFactory(jfxListCellFactory(server -> new TwoLineListItem(server.getName(), server.getUrl())));
         cboServers.setConverter(stringConverter(AuthlibInjectorServer::getName));
-        Bindings.bindContent(cboServers.getItems(), Settings.SETTINGS.authlibInjectorServers);
+        Bindings.bindContent(cboServers.getItems(), ConfigHolder.CONFIG.authlibInjectorServers);
         cboServers.getItems().addListener(onInvalidating(this::selectDefaultServer));
         selectDefaultServer();
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
@@ -21,9 +21,9 @@ import com.jfoenix.concurrency.JFXUtilities;
 import com.jfoenix.controls.*;
 
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
@@ -85,22 +85,22 @@ public class AddAccountPane extends StackPane {
         selectDefaultServer();
 
         cboType.getItems().setAll(i18n("account.methods.offline"), i18n("account.methods.yggdrasil"), i18n("account.methods.authlib_injector"));
-        cboType.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> {
-            txtPassword.setVisible(newValue.intValue() != 0);
-            lblPassword.setVisible(newValue.intValue() != 0);
-            cboServers.setVisible(newValue.intValue() == 2);
-            linkManageInjectorServers.setVisible(newValue.intValue() == 2);
-            lblInjectorServer.setVisible(newValue.intValue() == 2);
-            validateAcceptButton();
-        });
         cboType.getSelectionModel().select(0);
 
-        txtPassword.setOnAction(e -> onCreationAccept());
-        txtUsername.setOnAction(e -> onCreationAccept());
+        ReadOnlyIntegerProperty loginTypeIdProperty = cboType.getSelectionModel().selectedIndexProperty();
+
+        txtPassword.visibleProperty().bind(loginTypeIdProperty.isNotEqualTo(0));
+        lblPassword.visibleProperty().bind(txtPassword.visibleProperty());
+
+        cboServers.visibleProperty().bind(loginTypeIdProperty.isEqualTo(2));
+        lblInjectorServer.visibleProperty().bind(cboServers.visibleProperty());
+        linkManageInjectorServers.visibleProperty().bind(cboServers.visibleProperty());
+
         txtUsername.getValidators().add(new Validator(i18n("input.email"), str -> !txtPassword.isVisible() || str.contains("@")));
 
-        txtUsername.textProperty().addListener(it -> validateAcceptButton());
-        txtPassword.textProperty().addListener(it -> validateAcceptButton());
+        btnAccept.disableProperty().bind(Bindings.createBooleanBinding(
+                () -> !txtUsername.validate() || (loginTypeIdProperty.get() != 0 && !txtPassword.validate()),
+                txtUsername.textProperty(), txtPassword.textProperty(), loginTypeIdProperty));
     }
 
     /**
@@ -112,12 +112,11 @@ public class AddAccountPane extends StackPane {
         }
     }
 
-    private void validateAcceptButton() {
-        btnAccept.setDisable(!txtUsername.validate() || (cboType.getSelectionModel().getSelectedIndex() != 0 && !txtPassword.validate()));
-    }
-
     @FXML
     private void onCreationAccept() {
+        if (btnAccept.isDisabled())
+            return;
+
         String username = txtUsername.getText();
         String password = txtPassword.getText();
         Object addtionalData;
@@ -149,6 +148,7 @@ public class AddAccountPane extends StackPane {
 
         acceptPane.showSpinner();
         lblCreationWarning.setText("");
+        setDisable(true);
 
         Task.ofResult("create_account", () -> factory.create(new Selector(), username, password, addtionalData, Settings.INSTANCE.getProxy()))
                 .finalized(Schedulers.javafx(), variables -> {
@@ -161,6 +161,7 @@ public class AddAccountPane extends StackPane {
                     } else {
                         lblCreationWarning.setText(accountException(exception));
                     }
+                    setDisable(false);
                     acceptPane.hideSpinner();
                 }).start();
     }
@@ -174,14 +175,6 @@ public class AddAccountPane extends StackPane {
     private void onManageInjecterServers() {
         fireEvent(new DialogCloseEvent());
         Controllers.navigate(Controllers.getServersPage());
-    }
-
-    private void showSelector(Node node) {
-        getChildren().setAll(node);
-    }
-
-    private void closeSelector() {
-        getChildren().setAll(layout);
     }
 
     private class Selector extends BorderPane implements CharacterSelector {
@@ -240,7 +233,7 @@ public class AddAccountPane extends StackPane {
                 listBox.add(accountItem);
             }
 
-            JFXUtilities.runInFX(() -> showSelector(this));
+            JFXUtilities.runInFX(() -> Controllers.dialog(this));
 
             try {
                 latch.await();
@@ -248,11 +241,11 @@ public class AddAccountPane extends StackPane {
                 if (selectedProfile == null)
                     throw new NoSelectedCharacterException(account);
 
-                JFXUtilities.runInFX(AddAccountPane.this::closeSelector);
-
                 return selectedProfile;
             } catch (InterruptedException ignore) {
                 throw new NoSelectedCharacterException(account);
+            } finally {
+                JFXUtilities.runInFX(() -> Selector.this.fireEvent(new DialogCloseEvent()));
             }
         }
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
@@ -22,7 +22,7 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 import java.io.IOException;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
-import org.jackhuang.hmcl.setting.Settings;
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
@@ -132,8 +132,8 @@ public class AddAuthlibInjectorServerPane extends StackPane {
 
     @FXML
     private void onAddFinish() {
-        if (!Settings.SETTINGS.authlibInjectorServers.contains(serverBeingAdded)) {
-            Settings.SETTINGS.authlibInjectorServers.add(serverBeingAdded);
+        if (!ConfigHolder.CONFIG.authlibInjectorServers.contains(serverBeingAdded)) {
+            ConfigHolder.CONFIG.authlibInjectorServers.add(serverBeingAdded);
         }
         fireEvent(new DialogCloseEvent());
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
@@ -95,6 +95,11 @@ public class AddAuthlibInjectorServerPane extends StackPane {
 
     @FXML
     private void onAddNext() {
+        if (btnAddNext.isDisabled())
+            return;
+
+        lblCreationWarning.setText("");
+
         String url = fixInputUrl(txtServerUrl.getText());
 
         nextPane.showSpinner();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AuthlibInjectorServersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AuthlibInjectorServersPage.java
@@ -22,7 +22,7 @@ import static org.jackhuang.hmcl.ui.FXUtils.loadFXML;
 import static org.jackhuang.hmcl.ui.FXUtils.smoothScrolling;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
-import org.jackhuang.hmcl.setting.Settings;
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.ui.wizard.DecoratorPage;
 
 import javafx.beans.InvalidationListener;
@@ -48,15 +48,15 @@ public class AuthlibInjectorServersPage extends StackPane implements DecoratorPa
         smoothScrolling(scrollPane);
 
         serversListener = observable -> updateServersList();
-        Settings.SETTINGS.authlibInjectorServers.addListener(new WeakInvalidationListener(serversListener));
+        ConfigHolder.CONFIG.authlibInjectorServers.addListener(new WeakInvalidationListener(serversListener));
         updateServersList();
     }
 
     private void updateServersList() {
         listPane.getChildren().setAll(
-                Settings.SETTINGS.authlibInjectorServers.stream()
+                ConfigHolder.CONFIG.authlibInjectorServers.stream()
                         .map(server -> new AuthlibInjectorServerItem(server,
-                                item -> Settings.SETTINGS.authlibInjectorServers.remove(item.getServer())))
+                                item -> ConfigHolder.CONFIG.authlibInjectorServers.remove(item.getServer())))
                         .collect(toList()));
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -23,6 +23,7 @@ import org.jackhuang.hmcl.game.HMCLModpackExportTask;
 import org.jackhuang.hmcl.game.HMCLModpackManager;
 import org.jackhuang.hmcl.mod.Modpack;
 import org.jackhuang.hmcl.setting.Config;
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.setting.Settings;
 import org.jackhuang.hmcl.task.Task;
@@ -93,7 +94,7 @@ public final class ExportWizardProvider implements WizardProvider {
                             config.logLines.set(100);
                             config.configurations.clear();
 
-                            zip.putTextFile(config.toJson(), Settings.SETTINGS_FILE_NAME);
+                            zip.putTextFile(config.toJson(), ConfigHolder.CONFIG_FILENAME);
                             zip.putFile(tempModpack, "modpack.zip");
 
                             File bg = new File("bg").getAbsoluteFile();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -93,7 +93,7 @@ public final class ExportWizardProvider implements WizardProvider {
                             config.logLines.set(100);
                             config.configurations.clear();
 
-                            zip.putTextFile(Settings.GSON.toJson(config), Settings.SETTINGS_FILE_NAME);
+                            zip.putTextFile(config.toJson(), Settings.SETTINGS_FILE_NAME);
                             zip.putFile(tempModpack, "modpack.zip");
 
                             File bg = new File("bg").getAbsoluteFile();

--- a/HMCL/src/main/resources/assets/fxml/account-add.fxml
+++ b/HMCL/src/main/resources/assets/fxml/account-add.fxml
@@ -37,7 +37,7 @@
                 <Label text="%account.username" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
 
                 <JFXTextField fx:id="txtUsername" GridPane.columnIndex="1" GridPane.rowIndex="2" GridPane.columnSpan="2"
-                              FXUtils.validateWhileTextChanged="true">
+                              FXUtils.validateWhileTextChanged="true" onAction="#onCreationAccept">
                     <validators>
                         <RequiredFieldValidator message="%input.not_empty">
                         </RequiredFieldValidator>
@@ -47,7 +47,7 @@
                 <Label fx:id="lblPassword" text="%account.password" GridPane.rowIndex="3" GridPane.columnIndex="0"/>
 
                 <JFXPasswordField fx:id="txtPassword" GridPane.columnIndex="1" GridPane.rowIndex="3"
-                                  GridPane.columnSpan="2" FXUtils.validateWhileTextChanged="true">
+                                  GridPane.columnSpan="2" FXUtils.validateWhileTextChanged="true" onAction="#onCreationAccept">
                     <validators>
                         <RequiredFieldValidator message="%input.not_empty">
                         </RequiredFieldValidator>

--- a/HMCL/src/main/resources/assets/fxml/authlib-injector-server-add.fxml
+++ b/HMCL/src/main/resources/assets/fxml/authlib-injector-server-add.fxml
@@ -16,7 +16,7 @@
                 <Label text="%account.injector.add" />
             </heading>
             <body>
-                <JFXTextField fx:id="txtServerUrl" promptText="%account.injector.server_url">
+                <JFXTextField fx:id="txtServerUrl" promptText="%account.injector.server_url" onAction="#onAddNext">
                     <validators>
                         <URLValidator message="%input.url">
                             <protocols>


### PR DESCRIPTION
* 配置序列化/反序列化移至 `Config` 类中
* `Settings` 中关于 `Config` 的读写移至 `ConfigHolder`，WIP
  * 由于改动较大，先进行合并防止冲突
* `AddAccountPane` 进行重构
  * 使用数据绑定替代监听器
  * 使用 `Controllers.dialog` 来显示选择角色界面
  * 修复即使按钮禁用也可以通过回车继续
  * 在登录时禁用对话框
* `AddAuthlibInjectorServerPane` 支持回车下一步