### PR TITLE
完善账户信息页的显示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
@@ -85,15 +85,11 @@ public class AccountPage extends StackPane implements DecoratorPage {
             AuthlibInjectorServer server = ((AuthlibInjectorAccount) account).getServer();
             lblServer.setText(server.getName());
             installTooltip(lblServer, server.getUrl());
-            FXUtils.setLimitHeight(this, 182);
         } else {
             componentList.removeChildren(paneServer);
 
             if (account instanceof OfflineAccount) {
                 componentList.removeChildren(paneEmail);
-                FXUtils.setLimitHeight(this, 110);
-            } else {
-                FXUtils.setLimitHeight(this, 145);
             }
         }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
@@ -31,6 +31,7 @@ import javafx.scene.layout.StackPane;
 
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorAccount;
+import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.auth.offline.OfflineAccount;
 import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilAccount;
 import org.jackhuang.hmcl.game.AccountHelper;
@@ -39,6 +40,8 @@ import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.construct.ComponentList;
 import org.jackhuang.hmcl.ui.wizard.DecoratorPage;
+
+import static org.jackhuang.hmcl.ui.FXUtils.installTooltip;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 import java.util.Optional;
@@ -79,7 +82,9 @@ public class AccountPage extends StackPane implements DecoratorPage {
         FXUtils.loadFXML(this, "/assets/fxml/account.fxml");
 
         if (account instanceof AuthlibInjectorAccount) {
-            lblServer.setText(((AuthlibInjectorAccount) account).getServer().getName());
+            AuthlibInjectorServer server = ((AuthlibInjectorAccount) account).getServer();
+            lblServer.setText(server.getName());
+            installTooltip(lblServer, server.getUrl());
             FXUtils.setLimitHeight(this, 182);
         } else {
             componentList.removeChildren(paneServer);
@@ -87,8 +92,9 @@ public class AccountPage extends StackPane implements DecoratorPage {
             if (account instanceof OfflineAccount) {
                 componentList.removeChildren(paneEmail);
                 FXUtils.setLimitHeight(this, 110);
-            } else
+            } else {
                 FXUtils.setLimitHeight(this, 145);
+            }
         }
 
         btnDelete.setGraphic(SVG.delete(Theme.blackFillBinding(), 15, 15));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AccountPage.java
@@ -78,7 +78,6 @@ public class AccountPage extends StackPane implements DecoratorPage {
 
         FXUtils.loadFXML(this, "/assets/fxml/account.fxml");
 
-        FXUtils.setLimitWidth(this, 300);
         if (account instanceof AuthlibInjectorAccount) {
             lblServer.setText(((AuthlibInjectorAccount) account).getServer().getName());
             FXUtils.setLimitHeight(this, 182);

--- a/HMCL/src/main/resources/assets/fxml/account.fxml
+++ b/HMCL/src/main/resources/assets/fxml/account.fxml
@@ -77,19 +77,18 @@
                 </right>
             </BorderPane>
         </ComponentList>
-
+        <BorderPane pickOnBounds="false" style="-fx-padding: 4;">
+            <left>
+                <JFXButton BorderPane.alignment="BOTTOM_LEFT" fx:id="btnDelete" onMouseClicked="#onDelete"
+                           styleClass="toggle-icon4" maxWidth="30" maxHeight="30" minWidth="30" minHeight="30"
+                           prefWidth="30" prefHeight="30"/>
+            </left>
+            <right>
+                <JFXButton BorderPane.alignment="BOTTOM_RIGHT" fx:id="btnRefresh" onMouseClicked="#onRefresh"
+                           styleClass="toggle-icon4" maxWidth="30" maxHeight="30" minWidth="30" minHeight="30"
+                           prefWidth="30" prefHeight="30"/>
+            </right>
+        </BorderPane>
     </VBox>
-    <BorderPane pickOnBounds="false" style="-fx-padding: 4;">
-        <left>
-            <JFXButton BorderPane.alignment="BOTTOM_LEFT" fx:id="btnDelete" onMouseClicked="#onDelete"
-                       styleClass="toggle-icon4" maxWidth="30" maxHeight="30" minWidth="30" minHeight="30"
-                       prefWidth="30" prefHeight="30"/>
-        </left>
-        <right>
-            <JFXButton BorderPane.alignment="BOTTOM_RIGHT" fx:id="btnRefresh" onMouseClicked="#onRefresh"
-                       styleClass="toggle-icon4" maxWidth="30" maxHeight="30" minWidth="30" minHeight="30"
-                       prefWidth="30" prefHeight="30"/>
-        </right>
-    </BorderPane>
     <JFXProgressBar fx:id="progressBar" StackPane.alignment="TOP_CENTER" visible="false" />
 </fx:root>

--- a/HMCL/src/main/resources/assets/fxml/account.fxml
+++ b/HMCL/src/main/resources/assets/fxml/account.fxml
@@ -2,6 +2,7 @@
 
 <?import com.jfoenix.controls.JFXButton?>
 <?import javafx.scene.control.*?>
+<?import javafx.geometry.*?>
 <?import javafx.scene.layout.*?>
 <?import org.jackhuang.hmcl.ui.construct.ComponentList?>
 <?import com.jfoenix.controls.JFXProgressBar?>
@@ -20,6 +21,9 @@
                 </left>
                 <right>
                     <VBox>
+                        <BorderPane.margin>
+                            <Insets left="15.0" />
+                        </BorderPane.margin>
                         <Label fx:id="lblType" BorderPane.alignment="CENTER_LEFT"/>
                     </VBox>
                 </right>
@@ -33,6 +37,9 @@
                 </left>
                 <right>
                     <VBox>
+                        <BorderPane.margin>
+                            <Insets left="15.0" />
+                        </BorderPane.margin>
                         <Label fx:id="lblCharacter" BorderPane.alignment="CENTER_LEFT"/>
                     </VBox>
                 </right>
@@ -46,6 +53,9 @@
                 </left>
                 <right>
                     <VBox>
+                        <BorderPane.margin>
+                            <Insets left="15.0" />
+                        </BorderPane.margin>
                         <Label fx:id="lblEmail" BorderPane.alignment="CENTER_LEFT"/>
                     </VBox>
                 </right>
@@ -59,6 +69,9 @@
                 </left>
                 <right>
                     <VBox>
+                        <BorderPane.margin>
+                            <Insets left="15.0" />
+                        </BorderPane.margin>
                         <Label fx:id="lblServer" BorderPane.alignment="CENTER_LEFT"/>
                     </VBox>
                 </right>


### PR DESCRIPTION
* 修复账户信息页某项字段太长时，面板上下宽度不一致的问题。
* 在字段名称和字段值之间，插入 15px 间隙
* 当鼠标放在服务器名称上时，tooltip 显示服务器 URL
* 删除手动设置大小的代码，让 JavaFX 自己布局