### PR TITLE
当无法读写 hmcl.json 时弹框提示

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -17,6 +17,8 @@
  */
 package org.jackhuang.hmcl;
 
+import static org.jackhuang.hmcl.util.Logging.LOG;
+
 import com.jfoenix.concurrency.JFXUtilities;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -34,6 +36,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -79,11 +82,13 @@ public final class Launcher extends Application {
             Constants.UI_THREAD_SCHEDULER = Constants.JAVAFX_UI_THREAD_SCHEDULER;
             UPGRADER.parseArguments(VersionNumber.asVersion(VERSION), Arrays.asList(args));
 
-            Logging.LOG.info("*** " + TITLE + " ***");
-            Logging.LOG.info("Operating System: " + System.getProperty("os.name") + ' ' + OperatingSystem.SYSTEM_VERSION);
-            Logging.LOG.info("Java Version: " + System.getProperty("java.version") + ", " + System.getProperty("java.vendor"));
-            Logging.LOG.info("Java VM Version: " + System.getProperty("java.vm.name") + " (" + System.getProperty("java.vm.info") + "), " + System.getProperty("java.vm.vendor"));
-            Logging.LOG.info("Java Home: " + System.getProperty("java.home"));
+            LOG.info("*** " + TITLE + " ***");
+            LOG.info("Operating System: " + System.getProperty("os.name") + ' ' + OperatingSystem.SYSTEM_VERSION);
+            LOG.info("Java Version: " + System.getProperty("java.version") + ", " + System.getProperty("java.vendor"));
+            LOG.info("Java VM Version: " + System.getProperty("java.vm.name") + " (" + System.getProperty("java.vm.info") + "), " + System.getProperty("java.vm.vendor"));
+            LOG.info("Java Home: " + System.getProperty("java.home"));
+            LOG.info("Current Directory: " + Paths.get("").toAbsolutePath());
+            LOG.info("HMCL Directory: " + HMCL_DIRECTORY);
 
             launch(args);
         } catch (Throwable e) { // Fucking JavaFX will suppress the exception and will break our crash reporter.
@@ -92,7 +97,7 @@ public final class Launcher extends Application {
     }
 
     public static void stopApplication() {
-        Logging.LOG.info("Stopping application.\n" + StringUtils.getStackTrace(Thread.currentThread().getStackTrace()));
+        LOG.info("Stopping application.\n" + StringUtils.getStackTrace(Thread.currentThread().getStackTrace()));
 
         JFXUtilities.runInFX(() -> {
             if (Controllers.getStage() == null)
@@ -106,7 +111,7 @@ public final class Launcher extends Application {
     }
 
     public static void stopWithoutPlatform() {
-        Logging.LOG.info("Stopping application without JavaFX Toolkit.\n" + StringUtils.getStackTrace(Thread.currentThread().getStackTrace()));
+        LOG.info("Stopping application without JavaFX Toolkit.\n" + StringUtils.getStackTrace(Thread.currentThread().getStackTrace()));
 
         JFXUtilities.runInFX(() -> {
             if (Controllers.getStage() == null)

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -21,6 +21,8 @@ import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -40,6 +42,7 @@ public final class Main {
         checkJavaFX();
         checkDirectoryPath();
         checkDSTRootCAX3();
+        checkConfigPermission();
 
         ConfigHolder.init();
         Launcher.main(args);
@@ -82,6 +85,22 @@ public final class Main {
             }
         }
         showWarningAndContinue(i18n("fatal.missing_dst_root_ca_x3"));
+    }
+
+    private static void checkConfigPermission() {
+        Path config = ConfigHolder.CONFIG_PATH;
+        if (Files.exists(config)) {
+            if (Files.isReadable(config) && Files.isWritable(config)) {
+                // we are able to read & write the existent config
+                return;
+            }
+        } else {
+            if (Files.isWritable(config.getParent())) {
+                // we are able to create a new config
+                return;
+            }
+        }
+        showErrorAndExit(i18n("fatal.config_access_denied", config));
     }
 
     /**

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -32,12 +32,16 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import javax.swing.JOptionPane;
 
+import org.jackhuang.hmcl.setting.ConfigHolder;
+
 public final class Main {
 
     public static void main(String[] args) {
         checkJavaFX();
         checkDirectoryPath();
         checkDSTRootCAX3();
+
+        ConfigHolder.init();
         Launcher.main(args);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameDownloadTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameDownloadTask.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 /**
  * @author huangyuhui

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameDownloadTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameDownloadTask.java
@@ -63,7 +63,7 @@ public class HMCLGameDownloadTask extends Task {
 
         // Force using common directory will not affect the behaviour that repository acts
         // Since we always copy the downloaded jar to .minecraft/versions/<version>/
-        File cache = new File(Optional.ofNullable(Settings.INSTANCE.getCommonDirectory())
+        File cache = new File(Optional.ofNullable(Settings.instance().getCommonDirectory())
                 .orElse(Settings.getDefaultCommonDirectory()),
                 "jars/" + gameVersion + ".jar");
         if (cache.exists())

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -58,10 +58,10 @@ public class HMCLGameRepository extends DefaultGameRepository {
 
     @Override
     public File getAssetDirectory(String version, String assetId) {
-        if (Settings.INSTANCE.isCommonDirectoryDisabled() || useSelf(assetId))
+        if (Settings.instance().isCommonDirectoryDisabled() || useSelf(assetId))
             return super.getAssetDirectory(version, assetId);
         else
-            return new File(Settings.INSTANCE.getCommonDirectory(), "assets");
+            return new File(Settings.instance().getCommonDirectory(), "assets");
     }
 
     @Override
@@ -83,10 +83,10 @@ public class HMCLGameRepository extends DefaultGameRepository {
     public File getLibraryFile(Version version, Library lib) {
         VersionSetting vs = profile.getVersionSetting(version.getId());
         File self = super.getLibraryFile(version, lib);
-        if (Settings.INSTANCE.isCommonDirectoryDisabled() || self.exists())
+        if (Settings.instance().isCommonDirectoryDisabled() || self.exists())
             return self;
         else
-            return new File(Settings.INSTANCE.getCommonDirectory(), "libraries/" + lib.getPath());
+            return new File(Settings.instance().getCommonDirectory(), "libraries/" + lib.getPath());
     }
 
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.logging.Level;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class HMCLGameRepository extends DefaultGameRepository {
     private final Profile profile;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -378,7 +378,7 @@ public final class LauncherHelper {
                 System.out.print(log);
 
             logs.add(pair(log, level));
-            if (logs.size() > Settings.INSTANCE.getLogLines())
+            if (logs.size() > Settings.instance().getLogLines())
                 logs.removeFirst();
 
             if (setting.isShowLogs()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 
 import static java.util.stream.Collectors.toList;
 import static javafx.collections.FXCollections.observableArrayList;
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.ui.FXUtils.onInvalidating;
 import static org.jackhuang.hmcl.util.Lang.mapOf;
 import static org.jackhuang.hmcl.util.Logging.LOG;
@@ -125,7 +125,7 @@ public final class Accounts {
             // selection is valid, store it
             if (!initialized)
                 return;
-            CONFIG.setSelectedAccount(selected == null ? "" : accountId(selected));
+            config().setSelectedAccount(selected == null ? "" : accountId(selected));
         }
     };
 
@@ -144,7 +144,7 @@ public final class Accounts {
         if (!initialized)
             return;
         // update storage
-        CONFIG.getAccountStorages().setAll(
+        config().getAccountStorages().setAll(
                 accounts.stream()
                         .map(account -> {
                             Map<Object, Object> storage = account.toStorage();
@@ -155,14 +155,14 @@ public final class Accounts {
     }
 
     /**
-     * Called when it's ready to load accounts from {@link ConfigHolder#CONFIG}.
+     * Called when it's ready to load accounts from {@link ConfigHolder#config()}.
      */
     static void init() {
         if (initialized)
             throw new IllegalStateException("Already initialized");
 
         // load accounts
-        CONFIG.getAccountStorages().forEach(storage -> {
+        config().getAccountStorages().forEach(storage -> {
             AccountFactory<?> factory = type2factory.get(storage.get("type"));
             if (factory == null) {
                 LOG.warning("Unrecognized account type: " + storage);
@@ -180,12 +180,12 @@ public final class Accounts {
 
         initialized = true;
 
-        CONFIG.getAuthlibInjectorServers().addListener(onInvalidating(Accounts::removeDanglingAuthlibInjectorAccounts));
+        config().getAuthlibInjectorServers().addListener(onInvalidating(Accounts::removeDanglingAuthlibInjectorAccounts));
 
         // load selected account
         selectedAccount.set(
                 accounts.stream()
-                        .filter(it -> accountId(it).equals(CONFIG.getSelectedAccount()))
+                        .filter(it -> accountId(it).equals(config().getSelectedAccount()))
                         .findFirst()
                         .orElse(null));
     }
@@ -212,7 +212,7 @@ public final class Accounts {
 
     // ==== authlib-injector ====
     private static AuthlibInjectorServer getOrCreateAuthlibInjectorServer(String url) {
-        return CONFIG.getAuthlibInjectorServers().stream()
+        return config().getAuthlibInjectorServers().stream()
                 .filter(server -> url.equals(server.getUrl()))
                 .findFirst()
                 .orElseGet(() -> {
@@ -226,7 +226,7 @@ public final class Accounts {
                         LOG.log(Level.WARNING, "Failed to migrate authlib injector server " + url, e);
                     }
 
-                    CONFIG.getAuthlibInjectorServers().add(server);
+                    config().getAuthlibInjectorServers().add(server);
                     return server;
                 });
     }
@@ -239,7 +239,7 @@ public final class Accounts {
         accounts.stream()
                 .filter(AuthlibInjectorAccount.class::isInstance)
                 .map(AuthlibInjectorAccount.class::cast)
-                .filter(it -> !CONFIG.getAuthlibInjectorServers().contains(it.getServer()))
+                .filter(it -> !config().getAuthlibInjectorServers().contains(it.getServer()))
                 .collect(toList())
                 .forEach(accounts::remove);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Accounts.java
@@ -60,7 +60,7 @@ public final class Accounts {
     public static final OfflineAccountFactory FACTORY_OFFLINE = OfflineAccountFactory.INSTANCE;
     public static final YggdrasilAccountFactory FACTORY_YGGDRASIL = new YggdrasilAccountFactory(MojangYggdrasilProvider.INSTANCE);
     public static final AuthlibInjectorAccountFactory FACTORY_AUTHLIB_INJECTOR = new AuthlibInjectorAccountFactory(
-            new AuthlibInjectorDownloader(Launcher.HMCL_DIRECTORY.toPath(), () -> Settings.INSTANCE.getDownloadProvider())::getArtifactInfo,
+            new AuthlibInjectorDownloader(Launcher.HMCL_DIRECTORY.toPath(), () -> Settings.instance().getDownloadProvider())::getArtifactInfo,
             Accounts::getOrCreateAuthlibInjectorServer);
 
     private static final String TYPE_OFFLINE = "offline";

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -33,6 +33,8 @@ import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.util.EnumOrdinalDeserializer;
 import org.jackhuang.hmcl.util.FileTypeAdapter;
 import org.jackhuang.hmcl.util.ObservableHelper;
+import org.jackhuang.hmcl.util.i18n.Locales;
+import org.jackhuang.hmcl.util.i18n.Locales.SupportedLocale;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -67,6 +69,7 @@ public final class Config implements Cloneable, Observable {
             .registerTypeAdapter(ObservableMap.class, new ObservableMapCreator())
             .registerTypeAdapterFactory(new JavaFxPropertyTypeAdapterFactory(true, true))
             .registerTypeAdapter(Theme.class, new Theme.TypeAdapter())
+            .registerTypeAdapter(SupportedLocale.class, new SupportedLocale.TypeAdapter())
             .registerTypeAdapter(EnumBackgroundImage.class, new EnumOrdinalDeserializer<>(EnumBackgroundImage.class)) // backward compatibility for backgroundType
             .registerTypeAdapter(Proxy.Type.class, new EnumOrdinalDeserializer<>(Proxy.Type.class)) // backward compatibility for hasProxy
             .setPrettyPrinting()
@@ -120,7 +123,7 @@ public final class Config implements Cloneable, Observable {
     private ObjectProperty<Theme> theme = new SimpleObjectProperty<>(Theme.BLUE);
 
     @SerializedName("localization")
-    private StringProperty localization = new SimpleStringProperty();
+    private ObjectProperty<SupportedLocale> localization = new SimpleObjectProperty<>(Locales.DEFAULT);
 
     @SerializedName("downloadtype")
     private IntegerProperty downloadType = new SimpleIntegerProperty(1);
@@ -348,15 +351,15 @@ public final class Config implements Cloneable, Observable {
         return theme;
     }
 
-    public String getLocalization() {
+    public SupportedLocale getLocalization() {
         return localization.get();
     }
 
-    public void setLocalization(String localization) {
+    public void setLocalization(SupportedLocale localization) {
         this.localization.set(localization);
     }
 
-    public StringProperty localizationProperty() {
+    public ObjectProperty<SupportedLocale> localizationProperty() {
         return localization;
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -143,9 +143,6 @@ public final class Config implements Cloneable, Observable {
     @SerializedName("logLines")
     private IntegerProperty logLines = new SimpleIntegerProperty(100);
 
-    @SerializedName("firstLaunch")
-    private BooleanProperty firstLaunch = new SimpleBooleanProperty(true);
-
     @SerializedName("authlibInjectorServers")
     private ObservableList<AuthlibInjectorServer> authlibInjectorServers = FXCollections.observableArrayList();
 
@@ -429,18 +426,6 @@ public final class Config implements Cloneable, Observable {
 
     public IntegerProperty logLinesProperty() {
         return logLines;
-    }
-
-    public boolean isFirstLaunch() {
-        return firstLaunch.get();
-    }
-
-    public void setFirstLaunch(boolean firstLaunch) {
-        this.firstLaunch.set(firstLaunch);
-    }
-
-    public BooleanProperty firstLaunchProperty() {
-        return firstLaunch;
     }
 
     public ObservableList<AuthlibInjectorServer> getAuthlibInjectorServers() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -36,7 +36,14 @@ public final class ConfigHolder {
 
     public static final String CONFIG_FILENAME = "hmcl.json";
     public static final Path CONFIG_PATH = Paths.get(CONFIG_FILENAME).toAbsolutePath();
-    public static final Config CONFIG = initSettings();
+    private static Config configInstance = initSettings();
+
+    public static Config config() {
+        if (configInstance == null) {
+            throw new IllegalStateException("Configuration hasn't been loaded");
+        }
+        return configInstance;
+    }
 
     private static Config upgradeSettings(Config deserialized, Map<?, ?> rawJson) {
         if (!rawJson.containsKey("commonDirType"))
@@ -67,7 +74,7 @@ public final class ConfigHolder {
     static void saveConfig() {
         LOG.info("Saving config");
         try {
-            Files.write(CONFIG_PATH, CONFIG.toJson().getBytes(UTF_8));
+            Files.write(CONFIG_PATH, configInstance.toJson().getBytes(UTF_8));
         } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Failed to save config", ex);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -38,7 +38,6 @@ public final class ConfigHolder {
     public static final Path CONFIG_PATH = Paths.get(CONFIG_FILENAME).toAbsolutePath();
 
     private static Config configInstance;
-    private static boolean initialized;
     private static boolean newlyCreated;
 
     public static Config config() {
@@ -46,10 +45,6 @@ public final class ConfigHolder {
             throw new IllegalStateException("Configuration hasn't been loaded");
         }
         return configInstance;
-    }
-
-    public static boolean isInitialized() {
-        return initialized;
     }
 
     public static boolean isNewlyCreated() {
@@ -72,8 +67,6 @@ public final class ConfigHolder {
         if (newlyCreated) {
             saveConfig();
         }
-
-        initialized = true;
     }
 
     private static Config loadConfig() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -38,7 +38,7 @@ public final class ConfigHolder {
     public static final Path CONFIG_PATH = Paths.get(CONFIG_FILENAME).toAbsolutePath();
     public static final Config CONFIG = initSettings();
 
-    private static Config upgradeSettings(Config deserialized, Map rawJson) {
+    private static Config upgradeSettings(Config deserialized, Map<?, ?> rawJson) {
         if (!rawJson.containsKey("commonDirType"))
             deserialized.setCommonDirType(deserialized.getCommonDirectory().equals(Settings.getDefaultCommonDirectory()) ? EnumCommonDirectory.DEFAULT : EnumCommonDirectory.CUSTOM);
         return deserialized;
@@ -49,7 +49,7 @@ public final class ConfigHolder {
         if (Files.exists(CONFIG_PATH)) {
             try {
                 String json = new String(Files.readAllBytes(CONFIG_PATH), UTF_8);
-                Map raw = new Gson().fromJson(json, Map.class);
+                Map<?, ?> raw = new Gson().fromJson(json, Map.class);
                 Config deserialized = Config.fromJson(json);
                 if (deserialized == null) {
                     LOG.finer("Settings file is empty, use the default settings.");
@@ -64,9 +64,10 @@ public final class ConfigHolder {
         return config;
     }
 
-    static void saveConfig(Config config) {
+    static void saveConfig() {
+        LOG.info("Saving config");
         try {
-            Files.write(CONFIG_PATH, config.toJson().getBytes(UTF_8));
+            Files.write(CONFIG_PATH, CONFIG.toJson().getBytes(UTF_8));
         } catch (IOException ex) {
             LOG.log(Level.SEVERE, "Failed to save config", ex);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profile.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profile.java
@@ -122,7 +122,7 @@ public final class Profile {
     }
 
     public HMCLDependencyManager getDependency() {
-        return new HMCLDependencyManager(this, Settings.INSTANCE.getDownloadProvider());
+        return new HMCLDependencyManager(this, Settings.instance().getDownloadProvider());
     }
 
     public VersionSetting getVersionSetting(String id) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ProxyManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ProxyManager.java
@@ -17,7 +17,7 @@
  */
 package org.jackhuang.hmcl.setting;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 import java.net.Authenticator;
 import java.net.InetSocketAddress;
@@ -38,18 +38,18 @@ public final class ProxyManager {
 
     private static ObjectBinding<Proxy> proxyProperty = Bindings.createObjectBinding(
             () -> {
-                String host = CONFIG.getProxyHost();
-                Integer port = Lang.toIntOrNull(CONFIG.getProxyPort());
-                if (!CONFIG.hasProxy() || StringUtils.isBlank(host) || port == null || CONFIG.getProxyType() == Proxy.Type.DIRECT) {
+                String host = config().getProxyHost();
+                Integer port = Lang.toIntOrNull(config().getProxyPort());
+                if (!config().hasProxy() || StringUtils.isBlank(host) || port == null || config().getProxyType() == Proxy.Type.DIRECT) {
                     return Proxy.NO_PROXY;
                 } else {
-                    return new Proxy(CONFIG.getProxyType(), new InetSocketAddress(host, port));
+                    return new Proxy(config().getProxyType(), new InetSocketAddress(host, port));
                 }
             },
-            CONFIG.proxyTypeProperty(),
-            CONFIG.proxyHostProperty(),
-            CONFIG.proxyPortProperty(),
-            CONFIG.hasProxyProperty());
+            config().proxyTypeProperty(),
+            config().proxyHostProperty(),
+            config().proxyPortProperty(),
+            config().hasProxyProperty());
 
     public static Proxy getProxy() {
         return proxyProperty.get();
@@ -68,9 +68,9 @@ public final class ProxyManager {
 
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                if (CONFIG.hasProxyAuth()) {
-                    String username = CONFIG.getProxyUser();
-                    String password = CONFIG.getProxyPass();
+                if (config().hasProxyAuth()) {
+                    String username = config().getProxyUser();
+                    String password = config().getProxyPass();
                     if (username != null && password != null) {
                         return new PasswordAuthentication(username, password.toCharArray());
                     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -50,11 +50,7 @@ public class Settings {
         instance = new Settings();
     }
 
-    private final boolean firstLaunch;
-
     private Settings() {
-        firstLaunch = config().isFirstLaunch();
-
         ProxyManager.init();
         Accounts.init();
 
@@ -67,11 +63,6 @@ public class Settings {
         }
 
         config().addListener(source -> ConfigHolder.saveConfig());
-        config().setFirstLaunch(false);
-    }
-
-    public boolean isFirstLaunch() {
-        return firstLaunch;
     }
 
     private Locales.SupportedLocale locale = Locales.getLocaleByName(config().getLocalization());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -30,7 +30,7 @@ import org.jackhuang.hmcl.util.i18n.Locales;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class Settings {
 
@@ -39,7 +39,7 @@ public class Settings {
     private final boolean firstLaunch;
 
     private Settings() {
-        firstLaunch = CONFIG.isFirstLaunch();
+        firstLaunch = config().isFirstLaunch();
 
         ProxyManager.init();
         Accounts.init();
@@ -52,15 +52,15 @@ public class Settings {
             profileEntry.getValue().addPropertyChangedListener(e -> ConfigHolder.saveConfig());
         }
 
-        CONFIG.addListener(source -> ConfigHolder.saveConfig());
-        CONFIG.setFirstLaunch(false);
+        config().addListener(source -> ConfigHolder.saveConfig());
+        config().setFirstLaunch(false);
     }
 
     public boolean isFirstLaunch() {
         return firstLaunch;
     }
 
-    private Locales.SupportedLocale locale = Locales.getLocaleByName(CONFIG.getLocalization());
+    private Locales.SupportedLocale locale = Locales.getLocaleByName(config().getLocalization());
 
     public Locales.SupportedLocale getLocale() {
         return locale;
@@ -68,28 +68,28 @@ public class Settings {
 
     public void setLocale(Locales.SupportedLocale locale) {
         this.locale = locale;
-        CONFIG.setLocalization(Locales.getNameByLocale(locale));
+        config().setLocalization(Locales.getNameByLocale(locale));
     }
 
     public Font getFont() {
-        return Font.font(CONFIG.getFontFamily(), CONFIG.getFontSize());
+        return Font.font(config().getFontFamily(), config().getFontSize());
     }
 
     public void setFont(Font font) {
-        CONFIG.setFontFamily(font.getFamily());
-        CONFIG.setFontSize(font.getSize());
+        config().setFontFamily(font.getFamily());
+        config().setFontSize(font.getSize());
     }
 
     public int getLogLines() {
-        return Math.max(CONFIG.getLogLines(), 100);
+        return Math.max(config().getLogLines(), 100);
     }
 
     public void setLogLines(int logLines) {
-        CONFIG.setLogLines(logLines);
+        config().setLogLines(logLines);
     }
 
     public boolean isCommonDirectoryDisabled() {
-        return CONFIG.getCommonDirType() == EnumCommonDirectory.DISABLED;
+        return config().getCommonDirType() == EnumCommonDirectory.DISABLED;
     }
 
     public static String getDefaultCommonDirectory() {
@@ -97,13 +97,13 @@ public class Settings {
     }
 
     public String getCommonDirectory() {
-        switch (CONFIG.getCommonDirType()) {
+        switch (config().getCommonDirType()) {
             case DISABLED:
                 return null;
             case DEFAULT:
                 return getDefaultCommonDirectory();
             case CUSTOM:
-                return CONFIG.getCommonDirectory();
+                return config().getCommonDirectory();
             default:
                 return null;
         }
@@ -114,14 +114,14 @@ public class Settings {
      ****************************************/
 
     public DownloadProvider getDownloadProvider() {
-        return DownloadProviders.getDownloadProvider(CONFIG.getDownloadType());
+        return DownloadProviders.getDownloadProvider(config().getDownloadType());
     }
 
     public void setDownloadProvider(DownloadProvider downloadProvider) {
         int index = DownloadProviders.DOWNLOAD_PROVIDERS.indexOf(downloadProvider);
         if (index == -1)
             throw new IllegalArgumentException("Unknown download provider: " + downloadProvider);
-        CONFIG.setDownloadType(index);
+        config().setDownloadType(index);
     }
 
     /****************************************
@@ -131,18 +131,18 @@ public class Settings {
     public Profile getSelectedProfile() {
         checkProfileMap();
 
-        if (!hasProfile(CONFIG.getSelectedProfile())) {
+        if (!hasProfile(config().getSelectedProfile())) {
             getProfileMap().keySet().stream().findFirst().ifPresent(selectedProfile -> {
-                CONFIG.setSelectedProfile(selectedProfile);
+                config().setSelectedProfile(selectedProfile);
             });
             Schedulers.computation().schedule(this::onProfileChanged);
         }
-        return getProfile(CONFIG.getSelectedProfile());
+        return getProfile(config().getSelectedProfile());
     }
 
     public void setSelectedProfile(Profile selectedProfile) {
-        if (hasProfile(selectedProfile.getName()) && !Objects.equals(selectedProfile.getName(), CONFIG.getSelectedProfile())) {
-            CONFIG.setSelectedProfile(selectedProfile.getName());
+        if (hasProfile(selectedProfile.getName()) && !Objects.equals(selectedProfile.getName(), config().getSelectedProfile())) {
+            config().setSelectedProfile(selectedProfile.getName());
             Schedulers.computation().schedule(this::onProfileChanged);
         }
     }
@@ -159,7 +159,7 @@ public class Settings {
     }
 
     public Map<String, Profile> getProfileMap() {
-        return CONFIG.getConfigurations();
+        return config().getConfigurations();
     }
 
     public Collection<Profile> getProfiles() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -25,7 +25,6 @@ import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.event.*;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.util.*;
-import org.jackhuang.hmcl.util.i18n.Locales;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -63,17 +62,6 @@ public class Settings {
         }
 
         config().addListener(source -> ConfigHolder.saveConfig());
-    }
-
-    private Locales.SupportedLocale locale = Locales.getLocaleByName(config().getLocalization());
-
-    public Locales.SupportedLocale getLocale() {
-        return locale;
-    }
-
-    public void setLocale(Locales.SupportedLocale locale) {
-        this.locale = locale;
-        config().setLocalization(Locales.getNameByLocale(locale));
     }
 
     public Font getFont() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -27,12 +27,10 @@ import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.util.*;
 import org.jackhuang.hmcl.util.i18n.Locales;
 
-import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
-import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public class Settings {
 
@@ -51,16 +49,11 @@ public class Settings {
         for (Map.Entry<String, Profile> profileEntry : getProfileMap().entrySet()) {
             profileEntry.getValue().setName(profileEntry.getKey());
             profileEntry.getValue().nameProperty().setChangedListener(this::profileNameChanged);
-            profileEntry.getValue().addPropertyChangedListener(e -> save());
+            profileEntry.getValue().addPropertyChangedListener(e -> ConfigHolder.saveConfig());
         }
 
-        CONFIG.addListener(source -> save());
+        CONFIG.addListener(source -> ConfigHolder.saveConfig());
         CONFIG.setFirstLaunch(false);
-    }
-
-    private void save() {
-        LOG.info("Saving config");
-        ConfigHolder.saveConfig(CONFIG);
     }
 
     public boolean isFirstLaunch() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -34,10 +34,20 @@ import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class Settings {
 
-    private static Settings instance = new Settings();
+    private static Settings instance;
 
     public static Settings instance() {
+        if (instance == null) {
+            throw new IllegalStateException("Settings hasn't been initialized");
+        }
         return instance;
+    }
+
+    /**
+     * Should be called from {@link ConfigHolder#init()}.
+     */
+    static void init() {
+        instance = new Settings();
     }
 
     private final boolean firstLaunch;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Settings.java
@@ -34,7 +34,11 @@ import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class Settings {
 
-    public static final Settings INSTANCE = new Settings();
+    private static Settings instance = new Settings();
+
+    public static Settings instance() {
+        return instance;
+    }
 
     private final boolean firstLaunch;
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -27,7 +27,7 @@ import org.jackhuang.hmcl.util.Logging;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,7 +120,7 @@ public class Theme {
     }
 
     public static ObjectBinding<Color> foregroundFillBinding() {
-        return Bindings.createObjectBinding(() -> CONFIG.getTheme().getForegroundColor(), CONFIG.themeProperty());
+        return Bindings.createObjectBinding(() -> config().getTheme().getForegroundColor(), config().themeProperty());
     }
 
     public static ObjectBinding<Color> blackFillBinding() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/VersionSetting.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/VersionSetting.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 /**
  *
@@ -515,10 +515,10 @@ public final class VersionSetting {
                 .setFullscreen(isFullscreen())
                 .setServerIp(getServerIp())
                 .setWrapper(getWrapper())
-                .setProxyHost(CONFIG.getProxyHost())
-                .setProxyPort(CONFIG.getProxyPort())
-                .setProxyUser(CONFIG.getProxyUser())
-                .setProxyPass(CONFIG.getProxyPass())
+                .setProxyHost(config().getProxyHost())
+                .setProxyPort(config().getProxyPort())
+                .setProxyUser(config().getProxyUser())
+                .setProxyPass(config().getProxyPass())
                 .setPrecalledCommand(getPreLaunchCommand())
                 .setNoGeneratedJVMArgs(isNoJVMArgs())
                 .create();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAccountPane.java
@@ -54,7 +54,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 
 import static java.util.Objects.requireNonNull;
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.ui.FXUtils.jfxListCellFactory;
 import static org.jackhuang.hmcl.ui.FXUtils.onInvalidating;
 import static org.jackhuang.hmcl.ui.FXUtils.stringConverter;
@@ -79,7 +79,7 @@ public class AddAccountPane extends StackPane {
 
         cboServers.setCellFactory(jfxListCellFactory(server -> new TwoLineListItem(server.getName(), server.getUrl())));
         cboServers.setConverter(stringConverter(AuthlibInjectorServer::getName));
-        Bindings.bindContent(cboServers.getItems(), CONFIG.getAuthlibInjectorServers());
+        Bindings.bindContent(cboServers.getItems(), config().getAuthlibInjectorServers());
         cboServers.getItems().addListener(onInvalidating(this::selectDefaultServer));
         selectDefaultServer();
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AddAuthlibInjectorServerPane.java
@@ -39,7 +39,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class AddAuthlibInjectorServerPane extends StackPane {
 
@@ -133,8 +133,8 @@ public class AddAuthlibInjectorServerPane extends StackPane {
 
     @FXML
     private void onAddFinish() {
-        if (!CONFIG.getAuthlibInjectorServers().contains(serverBeingAdded)) {
-            CONFIG.getAuthlibInjectorServers().add(serverBeingAdded);
+        if (!config().getAuthlibInjectorServers().contains(serverBeingAdded)) {
+            config().getAuthlibInjectorServers().add(serverBeingAdded);
         }
         fireEvent(new DialogCloseEvent());
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/AuthlibInjectorServersPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/AuthlibInjectorServersPage.java
@@ -34,7 +34,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class AuthlibInjectorServersPage extends StackPane implements DecoratorPage {
     private final StringProperty title = new SimpleStringProperty(this, "title", i18n("account.injector.manage.title"));
@@ -49,13 +49,13 @@ public class AuthlibInjectorServersPage extends StackPane implements DecoratorPa
         loadFXML(this, "/assets/fxml/authlib-injector-servers.fxml");
         smoothScrolling(scrollPane);
 
-        serverItems = MappedObservableList.create(CONFIG.getAuthlibInjectorServers(), this::createServerItem);
+        serverItems = MappedObservableList.create(config().getAuthlibInjectorServers(), this::createServerItem);
         Bindings.bindContent(listPane.getChildren(), serverItems);
     }
 
     private AuthlibInjectorServerItem createServerItem(AuthlibInjectorServer server) {
         return new AuthlibInjectorServerItem(server,
-                item -> CONFIG.getAuthlibInjectorServers().remove(item.getServer()));
+                item -> config().getAuthlibInjectorServers().remove(item.getServer()));
     }
 
     @FXML

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -34,7 +34,7 @@ import org.jackhuang.hmcl.ui.construct.TaskExecutorDialogPane;
 import org.jackhuang.hmcl.util.FutureCallback;
 import org.jackhuang.hmcl.util.JavaVersion;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 import java.util.function.Consumer;
 
@@ -108,7 +108,7 @@ public final class Controllers {
         decorator.setCustomMaximize(false);
 
         scene = new Scene(decorator, 804, 521);
-        scene.getStylesheets().setAll(CONFIG.getTheme().getStylesheets());
+        scene.getStylesheets().setAll(config().getTheme().getStylesheets());
         stage.setMinWidth(804);
         stage.setMaxWidth(804);
         stage.setMinHeight(521);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -102,7 +102,7 @@ public final class Controllers {
         decorator.showPage(null);
         leftPaneController = new LeftPaneController(decorator.getLeftPane());
 
-        Settings.INSTANCE.onProfileLoading();
+        Settings.instance().onProfileLoading();
         Task.of(JavaVersion::initialize).start();
 
         decorator.setCustomMaximize(false);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -81,7 +81,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 
 import static java.util.stream.Collectors.toList;
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public final class Decorator extends StackPane implements TaskExecutorDialogWizardDisplayer {
@@ -228,8 +228,8 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
                 Bindings.createObjectBinding(
                         () -> {
                             Image image = null;
-                            if (CONFIG.getBackgroundImageType() == EnumBackgroundImage.CUSTOM && CONFIG.getBackgroundImage() != null) {
-                                image = tryLoadImage(Paths.get(CONFIG.getBackgroundImage()))
+                            if (config().getBackgroundImageType() == EnumBackgroundImage.CUSTOM && config().getBackgroundImage() != null) {
+                                image = tryLoadImage(Paths.get(config().getBackgroundImage()))
                                         .orElse(null);
                             }
                             if (image == null) {
@@ -237,8 +237,8 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
                             }
                             return new Background(new BackgroundImage(image, BackgroundRepeat.NO_REPEAT, BackgroundRepeat.NO_REPEAT, BackgroundPosition.DEFAULT, new BackgroundSize(800, 480, false, false, true, true)));
                         },
-                        CONFIG.backgroundImageTypeProperty(),
-                        CONFIG.backgroundImageProperty()));
+                        config().backgroundImageTypeProperty(),
+                        config().backgroundImageProperty()));
     }
 
     private Image defaultBackground = new Image("/assets/img/background.jpg");

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -200,7 +200,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
             );
             nowAnimation.play();
         });
-        if (!Settings.instance().isFirstLaunch() || Settings.instance().getLocale().getLocale() != Locale.CHINA)
+        if (/* TODO: is not first launch or */Settings.instance().getLocale().getLocale() != Locale.CHINA)
             drawerWrapper.getChildren().remove(welcomeView);
 
         if (!min) buttonsContainer.getChildren().remove(btnMin);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -57,7 +57,6 @@ import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorDnD;
 import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.EnumBackgroundImage;
-import org.jackhuang.hmcl.setting.Settings;
 import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.ui.animation.AnimationProducer;
 import org.jackhuang.hmcl.ui.animation.ContainerAnimations;
@@ -200,7 +199,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
             );
             nowAnimation.play();
         });
-        if (!ConfigHolder.isNewlyCreated() || Settings.instance().getLocale().getLocale() != Locale.CHINA)
+        if (!ConfigHolder.isNewlyCreated() || config().getLocalization().getLocale() != Locale.CHINA)
             drawerWrapper.getChildren().remove(welcomeView);
 
         if (!min) buttonsContainer.getChildren().remove(btnMin);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -55,6 +55,7 @@ import javafx.stage.StageStyle;
 import javafx.util.Duration;
 import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorDnD;
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.EnumBackgroundImage;
 import org.jackhuang.hmcl.setting.Settings;
 import org.jackhuang.hmcl.setting.Theme;
@@ -69,7 +70,6 @@ import org.jackhuang.hmcl.ui.wizard.*;
 import org.jackhuang.hmcl.util.Lang;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -200,7 +200,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
             );
             nowAnimation.play();
         });
-        if (/* TODO: is not first launch or */Settings.instance().getLocale().getLocale() != Locale.CHINA)
+        if (!ConfigHolder.isNewlyCreated() || Settings.instance().getLocale().getLocale() != Locale.CHINA)
             drawerWrapper.getChildren().remove(welcomeView);
 
         if (!min) buttonsContainer.getChildren().remove(btnMin);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -200,7 +200,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
             );
             nowAnimation.play();
         });
-        if (!Settings.INSTANCE.isFirstLaunch() || Settings.INSTANCE.getLocale().getLocale() != Locale.CHINA)
+        if (!Settings.instance().isFirstLaunch() || Settings.instance().getLocale().getLocale() != Locale.CHINA)
             drawerWrapper.getChildren().remove(welcomeView);
 
         if (!min) buttonsContainer.getChildren().remove(btnMin);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LeftPaneController.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LeftPaneController.java
@@ -216,11 +216,11 @@ public final class LeftPaneController {
 
     private void onProfilesLoading() {
         LinkedList<RipplerContainer> list = new LinkedList<>();
-        for (Profile profile : Settings.INSTANCE.getProfiles()) {
+        for (Profile profile : Settings.instance().getProfiles()) {
             VersionListItem item = new VersionListItem(Profiles.getProfileDisplayName(profile));
             RipplerContainer ripplerContainer = new RipplerContainer(item);
             item.setOnSettingsButtonClicked(e -> Controllers.getDecorator().showPage(new ProfilePage(profile)));
-            ripplerContainer.setOnMouseClicked(e -> Settings.INSTANCE.setSelectedProfile(profile));
+            ripplerContainer.setOnMouseClicked(e -> Settings.instance().setSelectedProfile(profile));
             ripplerContainer.getProperties().put("profile", profile.getName());
             ripplerContainer.maxWidthProperty().bind(leftPane.widthProperty());
             list.add(ripplerContainer);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -177,12 +177,12 @@ public final class LogWindow extends Stage {
 
             engine = webView.getEngine();
             engine.loadContent(Lang.ignoringException(() -> IOUtils.readFullyAsString(getClass().getResourceAsStream("/assets/log-window-content.html")))
-                    .replace("${FONT}", Settings.INSTANCE.getFont().getSize() + "px \"" + Settings.INSTANCE.getFont().getFamily() + "\""));
+                    .replace("${FONT}", Settings.instance().getFont().getSize() + "px \"" + Settings.instance().getFont().getFamily() + "\""));
             engine.getLoadWorker().stateProperty().addListener((a, b, newValue) -> {
                 if (newValue == Worker.State.SUCCEEDED) {
                     document = engine.getDocument();
                     body = document.getElementsByTagName("body").item(0);
-                    engine.executeScript("limitedLogs=" + Settings.INSTANCE.getLogLines());
+                    engine.executeScript("limitedLogs=" + Settings.instance().getLogLines());
                     latch.countDown();
                     onDone.fireEvent(new Event(LogWindow.this));
                 }
@@ -190,14 +190,14 @@ public final class LogWindow extends Stage {
 
             boolean flag = false;
             for (String i : cboLines.getItems())
-                if (Integer.toString(Settings.INSTANCE.getLogLines()).equals(i)) {
+                if (Integer.toString(Settings.instance().getLogLines()).equals(i)) {
                     cboLines.getSelectionModel().select(i);
                     flag = true;
                 }
 
             cboLines.getSelectionModel().selectedItemProperty().addListener((a, b, newValue) -> {
-                Settings.INSTANCE.setLogLines(newValue == null ? 100 : Integer.parseInt(newValue));
-                engine.executeScript("limitedLogs=" + Settings.INSTANCE.getLogLines());
+                Settings.instance().setLogLines(newValue == null ? 100 : Integer.parseInt(newValue));
+                engine.executeScript("limitedLogs=" + Settings.instance().getLogLines());
             });
 
             if (!flag)

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -43,7 +43,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 import java.util.concurrent.CountDownLatch;
@@ -65,7 +65,7 @@ public final class LogWindow extends Stage {
 
     public LogWindow() {
         setScene(new Scene(impl, 800, 480));
-        getScene().getStylesheets().addAll(CONFIG.getTheme().getStylesheets());
+        getScene().getStylesheets().addAll(config().getTheme().getStylesheets());
         setTitle(i18n("logwindow.title"));
         getIcons().add(new Image("/assets/img/icon.png"));
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/MainPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/MainPage.java
@@ -101,7 +101,7 @@ public final class MainPage extends StackPane implements DecoratorPage {
 
         btnAdd.setOnMouseClicked(e -> Controllers.getDecorator().startWizard(new DownloadWizardProvider(), i18n("install")));
         FXUtils.installTooltip(btnAdd, i18n("install"));
-        btnRefresh.setOnMouseClicked(e -> Settings.INSTANCE.getSelectedProfile().getRepository().refreshVersionsAsync().start());
+        btnRefresh.setOnMouseClicked(e -> Settings.instance().getSelectedProfile().getRepository().refreshVersionsAsync().start());
         FXUtils.installTooltip(btnRefresh, i18n("button.refresh"));
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ProfilePage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ProfilePage.java
@@ -80,7 +80,7 @@ public final class ProfilePage extends StackPane implements DecoratorPage {
     @FXML
     private void onDelete() {
         if (profile != null) {
-            Settings.INSTANCE.deleteProfile(profile);
+            Settings.instance().deleteProfile(profile);
             Controllers.navigate(null);
         }
     }
@@ -99,10 +99,10 @@ public final class ProfilePage extends StackPane implements DecoratorPage {
             }
             Profile newProfile = new Profile(txtProfileName.getText(), new File(getLocation()));
             newProfile.setUseRelativePath(toggleUseRelativePath.isSelected());
-            Settings.INSTANCE.putProfile(newProfile);
+            Settings.instance().putProfile(newProfile);
         }
 
-        Settings.INSTANCE.onProfileLoading();
+        Settings.instance().onProfileLoading();
         Controllers.navigate(null);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
@@ -47,7 +47,7 @@ import org.jackhuang.hmcl.ui.wizard.DecoratorPage;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.i18n.Locales;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 import java.net.Proxy;
@@ -142,16 +142,16 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
         cboLanguage.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.INSTANCE.setLocale(Locales.getLocale(newValue.intValue())));
 
         // ==== Proxy ====
-        txtProxyHost.textProperty().bindBidirectional(CONFIG.proxyHostProperty());
-        txtProxyPort.textProperty().bindBidirectional(CONFIG.proxyPortProperty());
-        txtProxyUsername.textProperty().bindBidirectional(CONFIG.proxyUserProperty());
-        txtProxyPassword.textProperty().bindBidirectional(CONFIG.proxyPassProperty());
+        txtProxyHost.textProperty().bindBidirectional(config().proxyHostProperty());
+        txtProxyPort.textProperty().bindBidirectional(config().proxyPortProperty());
+        txtProxyUsername.textProperty().bindBidirectional(config().proxyUserProperty());
+        txtProxyPassword.textProperty().bindBidirectional(config().proxyPassProperty());
 
         proxyPane.disableProperty().bind(chkEnableProxy.selectedProperty().not());
         authPane.disableProperty().bind(chkProxyAuthentication.selectedProperty().not());
 
-        chkEnableProxy.selectedProperty().bindBidirectional(CONFIG.hasProxyProperty());
-        chkProxyAuthentication.selectedProperty().bindBidirectional(CONFIG.hasProxyAuthProperty());
+        chkEnableProxy.selectedProperty().bindBidirectional(config().hasProxyProperty());
+        chkProxyAuthentication.selectedProperty().bindBidirectional(config().hasProxyAuthProperty());
 
         selectedProxyType = new SimpleObjectProperty<Proxy.Type>(Proxy.Type.HTTP) {
             {
@@ -169,7 +169,7 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
                 }
             }
         };
-        selectedProxyType.bindBidirectional(CONFIG.proxyTypeProperty());
+        selectedProxyType.bindBidirectional(config().proxyTypeProperty());
 
         ToggleGroup proxyConfigurationGroup = new ToggleGroup();
         chkProxyHttp.setUserData(Proxy.Type.HTTP);
@@ -188,12 +188,12 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
                 fileCommonLocation.createChildren(i18n("launcher.common_directory.disabled"), EnumCommonDirectory.DISABLED),
                 fileCommonLocation.createChildren(i18n("launcher.common_directory.default"), EnumCommonDirectory.DEFAULT)
         ), EnumCommonDirectory.CUSTOM);
-        fileCommonLocation.selectedDataProperty().bindBidirectional(CONFIG.commonDirTypeProperty());
-        fileCommonLocation.customTextProperty().bindBidirectional(CONFIG.commonDirectoryProperty());
+        fileCommonLocation.selectedDataProperty().bindBidirectional(config().commonDirTypeProperty());
+        fileCommonLocation.customTextProperty().bindBidirectional(config().commonDirectoryProperty());
         fileCommonLocation.subtitleProperty().bind(
                 Bindings.createObjectBinding(() -> Optional.ofNullable(Settings.INSTANCE.getCommonDirectory())
                                 .orElse(i18n("launcher.common_directory.disabled")),
-                        CONFIG.commonDirectoryProperty(), CONFIG.commonDirTypeProperty()));
+                        config().commonDirectoryProperty(), config().commonDirTypeProperty()));
 
         FXUtils.installTooltip(btnUpdate, i18n("update.tooltip"));
         checkUpdate();
@@ -202,22 +202,22 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
         backgroundItem.loadChildren(Collections.singletonList(
                 backgroundItem.createChildren(i18n("launcher.background.default"), EnumBackgroundImage.DEFAULT)
         ), EnumBackgroundImage.CUSTOM);
-        backgroundItem.customTextProperty().bindBidirectional(CONFIG.backgroundImageProperty());
-        backgroundItem.selectedDataProperty().bindBidirectional(CONFIG.backgroundImageTypeProperty());
+        backgroundItem.customTextProperty().bindBidirectional(config().backgroundImageProperty());
+        backgroundItem.selectedDataProperty().bindBidirectional(config().backgroundImageTypeProperty());
         backgroundItem.subtitleProperty().bind(
                 new When(backgroundItem.selectedDataProperty().isEqualTo(EnumBackgroundImage.DEFAULT))
                         .then(i18n("launcher.background.default"))
-                        .otherwise(CONFIG.backgroundImageProperty()));
+                        .otherwise(config().backgroundImageProperty()));
         // ====
 
         // ==== Theme ====
-        JFXColorPicker picker = new JFXColorPicker(Color.web(CONFIG.getTheme().getColor()), null);
+        JFXColorPicker picker = new JFXColorPicker(Color.web(config().getTheme().getColor()), null);
         picker.setCustomColorText(i18n("color.custom"));
         picker.setRecentColorsText(i18n("color.recent"));
         picker.getCustomColors().setAll(Theme.SUGGESTED_COLORS);
         picker.setOnAction(e -> {
             Theme theme = Theme.custom(Theme.getColorDisplayName(picker.getValue()));
-            CONFIG.setTheme(theme);
+            config().setTheme(theme);
             Controllers.getScene().getStylesheets().setAll(theme.getStylesheets());
         });
         themeColorPickerContainer.getChildren().setAll(picker);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
@@ -39,7 +39,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.setting.*;
-import org.jackhuang.hmcl.ui.construct.FileItem;
 import org.jackhuang.hmcl.ui.construct.FontComboBox;
 import org.jackhuang.hmcl.ui.construct.MultiFileItem;
 import org.jackhuang.hmcl.ui.construct.Validator;
@@ -135,11 +134,11 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
 
         ObservableList<Label> list = FXCollections.observableArrayList();
         for (Locales.SupportedLocale locale : Locales.LOCALES)
-            list.add(new Label(locale.getName(Settings.instance().getLocale().getResourceBundle())));
+            list.add(new Label(locale.getName(config().getLocalization().getResourceBundle())));
 
         cboLanguage.setItems(list);
-        cboLanguage.getSelectionModel().select(Locales.LOCALES.indexOf(Settings.instance().getLocale()));
-        cboLanguage.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.instance().setLocale(Locales.getLocale(newValue.intValue())));
+        cboLanguage.getSelectionModel().select(Locales.LOCALES.indexOf(config().getLocalization()));
+        cboLanguage.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> config().setLocalization(Locales.getLocale(newValue.intValue())));
 
         // ==== Proxy ====
         txtProxyHost.textProperty().bindBidirectional(config().proxyHostProperty());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/SettingsPage.java
@@ -111,35 +111,35 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
 
         FXUtils.smoothScrolling(scroll);
 
-        cboDownloadSource.getSelectionModel().select(DownloadProviders.DOWNLOAD_PROVIDERS.indexOf(Settings.INSTANCE.getDownloadProvider()));
-        cboDownloadSource.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.INSTANCE.setDownloadProvider(DownloadProviders.getDownloadProvider(newValue.intValue())));
+        cboDownloadSource.getSelectionModel().select(DownloadProviders.DOWNLOAD_PROVIDERS.indexOf(Settings.instance().getDownloadProvider()));
+        cboDownloadSource.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.instance().setDownloadProvider(DownloadProviders.getDownloadProvider(newValue.intValue())));
 
-        cboFont.getSelectionModel().select(Settings.INSTANCE.getFont().getFamily());
+        cboFont.getSelectionModel().select(Settings.instance().getFont().getFamily());
         cboFont.valueProperty().addListener((a, b, newValue) -> {
-            Font font = Font.font(newValue, Settings.INSTANCE.getFont().getSize());
-            Settings.INSTANCE.setFont(font);
+            Font font = Font.font(newValue, Settings.instance().getFont().getSize());
+            Settings.instance().setFont(font);
             lblDisplay.setStyle("-fx-font: " + font.getSize() + " \"" + font.getFamily() + "\";");
         });
 
-        txtFontSize.setText(Double.toString(Settings.INSTANCE.getFont().getSize()));
+        txtFontSize.setText(Double.toString(Settings.instance().getFont().getSize()));
         txtFontSize.getValidators().add(new Validator(it -> Lang.toDoubleOrNull(it) != null));
         txtFontSize.textProperty().addListener((a, b, newValue) -> {
             if (txtFontSize.validate()) {
-                Font font = Font.font(Settings.INSTANCE.getFont().getFamily(), Double.parseDouble(newValue));
-                Settings.INSTANCE.setFont(font);
+                Font font = Font.font(Settings.instance().getFont().getFamily(), Double.parseDouble(newValue));
+                Settings.instance().setFont(font);
                 lblDisplay.setStyle("-fx-font: " + font.getSize() + " \"" + font.getFamily() + "\";");
             }
         });
 
-        lblDisplay.setStyle("-fx-font: " + Settings.INSTANCE.getFont().getSize() + " \"" + Settings.INSTANCE.getFont().getFamily() + "\";");
+        lblDisplay.setStyle("-fx-font: " + Settings.instance().getFont().getSize() + " \"" + Settings.instance().getFont().getFamily() + "\";");
 
         ObservableList<Label> list = FXCollections.observableArrayList();
         for (Locales.SupportedLocale locale : Locales.LOCALES)
-            list.add(new Label(locale.getName(Settings.INSTANCE.getLocale().getResourceBundle())));
+            list.add(new Label(locale.getName(Settings.instance().getLocale().getResourceBundle())));
 
         cboLanguage.setItems(list);
-        cboLanguage.getSelectionModel().select(Locales.LOCALES.indexOf(Settings.INSTANCE.getLocale()));
-        cboLanguage.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.INSTANCE.setLocale(Locales.getLocale(newValue.intValue())));
+        cboLanguage.getSelectionModel().select(Locales.LOCALES.indexOf(Settings.instance().getLocale()));
+        cboLanguage.getSelectionModel().selectedIndexProperty().addListener((a, b, newValue) -> Settings.instance().setLocale(Locales.getLocale(newValue.intValue())));
 
         // ==== Proxy ====
         txtProxyHost.textProperty().bindBidirectional(config().proxyHostProperty());
@@ -191,7 +191,7 @@ public final class SettingsPage extends StackPane implements DecoratorPage {
         fileCommonLocation.selectedDataProperty().bindBidirectional(config().commonDirTypeProperty());
         fileCommonLocation.customTextProperty().bindBidirectional(config().commonDirectoryProperty());
         fileCommonLocation.subtitleProperty().bind(
-                Bindings.createObjectBinding(() -> Optional.ofNullable(Settings.INSTANCE.getCommonDirectory())
+                Bindings.createObjectBinding(() -> Optional.ofNullable(Settings.instance().getCommonDirectory())
                                 .orElse(i18n("launcher.common_directory.disabled")),
                         config().commonDirectoryProperty(), config().commonDirTypeProperty()));
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/WebStage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/WebStage.java
@@ -22,14 +22,14 @@ import javafx.scene.image.Image;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public class WebStage extends Stage {
     private final WebView webView = new WebView();
 
     public WebStage() {
         setScene(new Scene(webView, 800, 480));
-        getScene().getStylesheets().addAll(CONFIG.getTheme().getStylesheets());
+        getScene().getStylesheets().addAll(config().getTheme().getStylesheets());
         getIcons().add(new Image("/assets/img/icon.png"));
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadWizardProvider.java
@@ -41,7 +41,7 @@ public final class DownloadWizardProvider implements WizardProvider {
 
     @Override
     public void start(Map<String, Object> settings) {
-        profile = Settings.INSTANCE.getSelectedProfile();
+        profile = Settings.instance().getSelectedProfile();
         settings.put(PROFILE, profile);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -37,7 +37,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.jackhuang.hmcl.setting.ConfigHolder.CONFIG;
+import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
 public final class ExportWizardProvider implements WizardProvider {
     private final Profile profile;
@@ -83,11 +83,11 @@ public final class ExportWizardProvider implements WizardProvider {
 
                         try (ZipEngine zip = new ZipEngine(modpackFile)) {
                             Config exported = new Config();
-                            exported.setBackgroundImageType(CONFIG.getBackgroundImageType());
-                            exported.setBackgroundImage(CONFIG.getBackgroundImage());
-                            exported.setTheme(CONFIG.getTheme());
-                            exported.setDownloadType(CONFIG.getDownloadType());
-                            exported.getAuthlibInjectorServers().setAll(CONFIG.getAuthlibInjectorServers());
+                            exported.setBackgroundImageType(config().getBackgroundImageType());
+                            exported.setBackgroundImage(config().getBackgroundImage());
+                            exported.setTheme(config().getTheme());
+                            exported.setDownloadType(config().getDownloadType());
+                            exported.getAuthlibInjectorServers().setAll(config().getAuthlibInjectorServers());
                             zip.putTextFile(exported.toJson(), ConfigHolder.CONFIG_FILENAME);
                             zip.putFile(tempModpack, "modpack.zip");
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -24,7 +24,6 @@ import java.util.ResourceBundle;
 import java.util.logging.Level;
 
 import org.jackhuang.hmcl.setting.ConfigHolder;
-import org.jackhuang.hmcl.setting.Settings;
 
 public final class I18n {
 
@@ -32,7 +31,7 @@ public final class I18n {
 
     public static ResourceBundle getResourceBundle() {
         if (ConfigHolder.isInitialized()) {
-            return Settings.instance().getLocale().getResourceBundle();
+            return ConfigHolder.config().getLocalization().getResourceBundle();
         } else {
             return Locales.DEFAULT.getResourceBundle();
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -24,17 +24,24 @@ import java.util.ResourceBundle;
 import java.util.logging.Level;
 
 import org.jackhuang.hmcl.setting.ConfigHolder;
+import org.jackhuang.hmcl.util.i18n.Locales.SupportedLocale;
 
 public final class I18n {
 
     private I18n() {}
 
-    public static ResourceBundle getResourceBundle() {
-        if (ConfigHolder.isInitialized()) {
-            return ConfigHolder.config().getLocalization().getResourceBundle();
-        } else {
-            return Locales.DEFAULT.getResourceBundle();
+    private static SupportedLocale getCurrentLocale() {
+        try {
+            return ConfigHolder.config().getLocalization();
+        } catch (IllegalStateException e) {
+            // e is thrown by ConfigHolder.config(), indicating the config hasn't been loaded
+            // fallback to use default locale
+            return Locales.DEFAULT;
         }
+    }
+
+    public static ResourceBundle getResourceBundle() {
+        return getCurrentLocale().getResourceBundle();
     }
 
     public static String i18n(String key, Object... formatArgs) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -23,24 +23,19 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 
+import org.jackhuang.hmcl.setting.ConfigHolder;
 import org.jackhuang.hmcl.setting.Settings;
 
 public final class I18n {
 
     private I18n() {}
 
-    private static ResourceBundle RESOURCE_BUNDLE = null;
-
-    static {
-        try {
-            RESOURCE_BUNDLE = Settings.instance().getLocale().getResourceBundle();
-        } catch (Throwable e) {
-            LOG.log(Level.SEVERE, "Settings cannot be initialized", e);
-        }
-    }
-
     public static ResourceBundle getResourceBundle() {
-        return RESOURCE_BUNDLE == null ? Locales.DEFAULT.getResourceBundle() : RESOURCE_BUNDLE;
+        if (ConfigHolder.isInitialized()) {
+            return Settings.instance().getLocale().getResourceBundle();
+        } else {
+            return Locales.DEFAULT.getResourceBundle();
+        }
     }
 
     public static String i18n(String key, Object... formatArgs) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/I18n.java
@@ -33,7 +33,7 @@ public final class I18n {
 
     static {
         try {
-            RESOURCE_BUNDLE = Settings.INSTANCE.getLocale().getResourceBundle();
+            RESOURCE_BUNDLE = Settings.instance().getLocale().getResourceBundle();
         } catch (Throwable e) {
             LOG.log(Level.SEVERE, "Settings cannot be initialized", e);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
@@ -19,6 +19,10 @@ package org.jackhuang.hmcl.util.i18n;
 
 import org.jackhuang.hmcl.util.Lang;
 
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -106,6 +110,18 @@ public final class Locales {
         public String getName(ResourceBundle newResourceBundle) {
             if (name == null) return resourceBundle.getString("lang");
             else return newResourceBundle.getString(name);
+        }
+
+        public static class TypeAdapter extends com.google.gson.TypeAdapter<SupportedLocale> {
+            @Override
+            public void write(JsonWriter out, SupportedLocale value) throws IOException {
+                out.value(getNameByLocale(value));
+            }
+
+            @Override
+            public SupportedLocale read(JsonReader in) throws IOException {
+                return getLocaleByName(in.nextString());
+            }
         }
     }
 }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -93,6 +93,7 @@ extension.sh=Bash shell
 
 fatal.missing_javafx=JavaFX is missing.\nIf you are using Java 11 or later, please downgrade to Java 8 or 10.\nIf you are using OpenJDK, please ensure OpenJFX is included.
 fatal.missing_dst_root_ca_x3=The DST Root CA X3 certificate is missing on the current Java platform.\nYou can still use HMCL, but HMCL will be unable to connect to some sites (such as sites that use certificates issued by Let's Encrypt), which may cause HMCL not to function properly.\nPlease upgrade your Java to 8u101 or later to resolve the problem.
+fatal.config_access_denied=The configuration at "%s" is not readable or writable.\nPlease grant HMCL read and write access to this file and its parent directory.
 
 folder.config=Configs
 folder.coremod=Core Mod

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -93,6 +93,7 @@ extension.sh=Bash 腳本
 
 fatal.missing_javafx=JavaFX 缺失。\n如果您使用的是 Java 11 或更高版本，請降級到 Java 8 或 10。\n如果您使用的是 OpenJDK，請確保其包含 OpenJFX。
 fatal.missing_dst_root_ca_x3=當前 Java 平台缺少 DST Root CA X3 證書。\n您依然可以使用 HMCL，但將無法連接到部分站點（如使用 Let's Encrypt 證書的站點），這可能會使 HMCL 無法正常工作。\n請將您的 Java 升級到 8u101 以上以解決此問題。
+fatal.config_access_denied=HMCL 無法讀取或寫入位於 "%s" 的配置文件。\n請授予 HMCL 對該文件及其父目錄的讀寫權限。
 
 folder.config=配置文件夾
 folder.coremod=核心MOD文件夾

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -93,6 +93,7 @@ extension.sh=Bash 脚本
 
 fatal.missing_javafx=JavaFX 缺失。\n如果您使用的是 Java 11 或更高版本，请降级到 Java 8 或 10。\n如果您使用的是 OpenJDK，请确保其包含 OpenJFX。
 fatal.missing_dst_root_ca_x3=当前 Java 平台缺少 DST Root CA X3 证书。\n您依然可以使用 HMCL，但将无法连接到部分站点（如使用 Let's Encrypt 证书的站点），这可能会使 HMCL 无法正常工作。\n请将您的 Java 升级到 8u101 以上以解决此问题。
+fatal.config_access_denied=HMCL 无法读取或写入位于 "%s" 的配置文件。\n请授予 HMCL 对该文件及其父目录的读写权限。
 
 folder.config=配置文件夹
 folder.coremod=核心MOD文件夹


### PR DESCRIPTION
* 启动时检查对 `hmcl.json` 文件及其父目录的读写权限。若无读写权限，弹框提示并退出
* 启动时打印当前目录和 `.hmcl` 目录
* 用 `ConfigHolder.isNewlyCreated()` 替代 `isFirstLaunch`
* 新创建配置文件时触发一次保存
* 手动在 `Main` 中调用 `ConfigHolder.init()` 加载配置，而不是在类加载时
* `ConfigHolder.CONFIG` 变为 `ConfigHolder.config()`
* `Settings.INSTANCE` 变为 `Settings.instance()`
* 直接在 `Config` 中使用 `SupportedLocale` 类型