### PR TITLE
Mac 下恢复使用自定义窗口边框按钮

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Decorator.java
@@ -171,14 +171,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
 
         onCloseButtonAction = new SimpleObjectProperty<>(this, "onCloseButtonAction", Launcher::stopApplication);
 
-        switch (OperatingSystem.CURRENT_OS) {
-            case OSX:
-                titleContainer.setRight(null);
-                break;
-            default:
-                primaryStage.initStyle(StageStyle.UNDECORATED);
-                break;
-        }
+        primaryStage.initStyle(StageStyle.UNDECORATED);
         btnClose.setGraphic(close);
         btnMin.setGraphic(minus);
         btnMax.setGraphic(resizeMax);
@@ -310,11 +303,22 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
         }
         return Optional.empty();
     }
+
+    private boolean isMaximized() {
+        switch (OperatingSystem.CURRENT_OS) {
+            case OSX:
+                Rectangle2D bounds = Screen.getPrimary().getVisualBounds();
+                return primaryStage.getWidth() >= bounds.getWidth() && primaryStage.getHeight() >= bounds.getHeight();
+            default:
+                return primaryStage.isMaximized();
+        }
+    }
+
     // ====
 
     @FXML
     private void onMouseMoved(MouseEvent mouseEvent) {
-        if (!primaryStage.isMaximized() && !primaryStage.isFullScreen() && !maximized) {
+        if (!isMaximized() && !primaryStage.isFullScreen() && !maximized) {
             if (!primaryStage.isResizable())
                 updateInitMouseValues(mouseEvent);
             else {
@@ -363,7 +367,7 @@ public final class Decorator extends StackPane implements TaskExecutorDialogWiza
     private void onMouseDragged(MouseEvent mouseEvent) {
         this.isDragging = true;
         if (mouseEvent.isPrimaryButtonDown() && (this.xOffset != -1.0 || this.yOffset != -1.0)) {
-            if (!this.primaryStage.isFullScreen() && !mouseEvent.isStillSincePress() && !this.primaryStage.isMaximized() && !this.maximized) {
+            if (!this.primaryStage.isFullScreen() && !mouseEvent.isStillSincePress() && !isMaximized() && !this.maximized) {
                 this.newX = mouseEvent.getScreenX();
                 this.newY = mouseEvent.getScreenY();
                 double deltaX = this.newX - this.initX;


### PR DESCRIPTION
> 之前在 #413 里提供了显示原生窗口按钮作为临时解决方案，这里恢复为使用自定义窗口边框。

调试了下，找到了 Mac 下窗口不能移动的原因是 `primaryStage.isMaximized()` 在 Mac 下为 true，只要移除 `onMouseMoved` 和 `onMouseDragged` 方法中对它的判断 Mac 下就可以正常拖动窗口了。

调试时加了下面这段代码监控它的值变化：

```
primaryStage.maximizedProperty().addListener((observable, oldValue, newValue) -> {
    System.out.println(oldValue + " -> " + newValue);
});
```

发现是在窗口显示（`primaryStage.show()`）的时候变为 true 的，修改这个属性的地方在 natvie code 里，所以不知道问题出在哪。尝试过在 Listener 里把值改回去，但这样会导致窗口抖动（似乎 native code 还会把它设置回 true。。），所以解决方法就是 Mac 下别使用这个属性。