### PR TITLE
Ensure sequential execution of configuration writer threads

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -29,6 +29,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -118,14 +120,6 @@ public final class ConfigHolder {
         return new Config();
     }
 
-    private static InvocationDispatcher<String> configWriter = InvocationDispatcher.runOn(Lang::thread, content -> {
-        try {
-            writeToConfig(content);
-        } catch (IOException e) {
-            LOG.log(Level.SEVERE, "Failed to save config", e);
-        }
-    });
-
     private static void writeToConfig(String content) throws IOException {
         LOG.info("Saving config");
         synchronized (configLocation) {
@@ -133,8 +127,30 @@ public final class ConfigHolder {
         }
     }
 
+    // Ensure sequential execution of threads
+    private static ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    // Ensure sequential execution of threads
+    private static class ConfigWriteThread implements Runnable {
+        String content;
+
+        ConfigWriteThread(String content) {
+            this.content = content;
+        }
+
+        @Override
+        public void run() {
+            try {
+                writeToConfig(content);
+            } catch (IOException e) {
+                LOG.log(Level.SEVERE, "Failed to save config", e);
+            }
+        }
+    }
+
     static void markConfigDirty() {
-        configWriter.accept(configInstance.toJson());
+        // Ensure sequential execution of threads
+        executorService.execute(new ConfigWriteThread(configInstance.toJson()));
     }
 
     private static void saveConfigSync() throws IOException {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/InvocationDispatcher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/InvocationDispatcher.java
@@ -33,7 +33,9 @@ public class InvocationDispatcher<ARG> implements Consumer<ARG> {
 
     public static <ARG> InvocationDispatcher<ARG> runOn(Consumer<Runnable> executor, Consumer<ARG> action) {
         return new InvocationDispatcher<>(arg -> executor.accept(() -> {
-            action.accept(arg.get());
+            synchronized (action) {
+                action.accept(arg.get());
+            }
         }));
     }
 


### PR DESCRIPTION
确保配置文件保存时按照线程建立顺序执行。

最新Release中，对游戏目录列表中项目进行多次增、删、清空操作后，配置文件`hmcl.json`会保存文件不完整，导致各种清空下的游戏目录配置丢失。

经过对保存过程进行日志记录发现：

1. 某（几）次`synchronized`语句结束后，后续线程未能按照新建线程顺序进行执行；
2. 删除`synchronized`语句后，会导致某些情况下，多个保存线程冲突导致保存得到的配置文件混乱。

因此将原保存方式变换为使用`ExecutorService`进行队列式线程执行，测试（仅提交时最新分支javafx）得到的效果较好。

Signed-off-by: Chang Feng <chang_196700@hotmail.com>