### PR TITLE
Fix #586

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/CurseManifestFile.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/CurseManifestFile.java
@@ -83,7 +83,7 @@ public final class CurseManifestFile implements Validation {
     }
 
     public URL getUrl() {
-        return url == null ? NetworkUtils.toURL("https://minecraft.curseforge.com/projects/" + projectID + "/files/" + fileID + "/download")
+        return url == null ? NetworkUtils.toURL("https://www.curseforge.com/minecraft/mc-mods/" + projectID + "/download/" + fileID + "/file")
                 : NetworkUtils.toURL(url);
     }
 


### PR DESCRIPTION
Fix #586 .

Curseforge modpack broke cause of domain changes, resulting in it downloading the page of the mod rather than the mod itself.

This just update the link generated to the new way.