### PR TITLE
add up-to-date download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ HMCL is a Minecraft launcher which supports Mod management, game customizing, au
 
 No plugin API is provided.
 
+## Download
+Download the latest version [from the official website](https://hmcl.huangyuhui.net/download)
+
+Note: Github releases are outdated.
+
 ## License
 The software is distributed under [GPL v3](https://www.gnu.org/licenses/gpl-3.0.html) with additional terms.
 


### PR DESCRIPTION
I was always downloading from GitHub releases and I was wondering why there is no new version for months and many bugs weren't fixed. 

I just realized that the latest version is at https://hmcl.huangyuhui.net/download

this will guide people to the up-to-date version of HMCL.