### PR TITLE
feat: add mcm mirror

### DIFF
--- a/HMCL/settings.gradle
+++ b/HMCL/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'HMCL'
+rootProject.name = 'HMCL(MCM)'
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/DownloadProviders.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/DownloadProviders.java
@@ -21,9 +21,11 @@ import org.jackhuang.hmcl.download.AdaptedDownloadProvider;
 import org.jackhuang.hmcl.download.BMCLAPIDownloadProvider;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.download.MojangDownloadProvider;
+import org.jackhuang.hmcl.download.OMCMAPIDownloadProvider;
 import org.jackhuang.hmcl.ui.FXUtils;
 
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,9 +49,19 @@ public final class DownloadProviders {
         if (bmclapiRootOverride != null) bmclapiRoot = bmclapiRootOverride;
 
         providersById = mapOf(
-                pair("mojang", new MojangDownloadProvider()),
-                pair("bmclapi", new BMCLAPIDownloadProvider(bmclapiRoot)),
-                pair("mcbbs", new BMCLAPIDownloadProvider("https://download.mcbbs.net")));
+            pair("mojang", new MojangDownloadProvider()),
+            pair("bmclapi", new BMCLAPIDownloadProvider(bmclapiRoot)),
+            pair("mcbbs", new BMCLAPIDownloadProvider("https://download.mcbbs.net")),
+            pair("mcm", new OMCMAPIDownloadProvider(new HashMap<String, String>() {{
+                put("minecraft-meta", "http://mcm.xgheaven.com/minecraft/launcher-meta");
+                put("minecraft-launcher", "http://mcm.xgheaven.com/minecraft/launcher");
+                put("minecraft-libraries", "http://mcm.xgheaven.com/minecraft/libraries");
+                put("minecraft-resources", "http://mcm.xgheaven.com/minecraft/assets");
+                put("forge", "http://mcm.xgheaven.com/forge");
+                put("fabric-meta", "http://mcm.xgheaven.com/fabric/meta");
+                put("fabric-maven", "http://mcm.xgheaven.com/fabric/maven");
+            }}))
+        );
     }
 
     static void init() {

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -106,6 +106,7 @@ download.failed.refresh=Unable to download version list. Click here to retry.
 download.provider.mcbbs=MCBBS (https://www.mcbbs.net/)
 download.provider.bmclapi=BMCLAPI (bangbang93, https://bmclapi2.bangbang93.com/)
 download.provider.mojang=Mojang (OptiFine download service is provided by BMCLAPI)
+download.provider.mcm=Minecraft Mirror(http://mcm.xgheaven.com)
 
 extension.bat=Windows Bat file
 extension.mod=Mod file

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -99,6 +99,7 @@ download.failed.refresh=No se pudo cargar lista de versiones. Clic aquí para re
 download.provider.mcbbs=MCBBS (https://www.mcbbs.net/)
 download.provider.bmclapi=BMCLAPI (bangbang93, https://bmclapi2.bangbang93.com/)
 download.provider.mojang=Mojang (instalaciones de Forge y OptiFine siendo descargadas por BMCLAPI)
+download.provider.mcm=Minecraft Mirror(http://mcm.xgheaven.com)
 
 extension.bat=Windows archivo bat
 extension.mod=Archivo mod

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -101,6 +101,7 @@ download.failed.refresh=Невозможно загрузить список в�
 download.provider.mcbbs=MCBBS (https://www.mcbbs.net/)
 download.provider.bmclapi=BMCLAPI (bangbang93, https://bmclapi2.bangbang93.com/)
 download.provider.mojang=Mojang (Сервис загрузки OptiFine предоставлен BMCLAPI)
+download.provider.mcm=Minecraft Mirror(http://mcm.xgheaven.com)
 
 extension.bat=Пакетный файл Windows «bat»
 extension.mod=Файл мода

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -106,6 +106,7 @@ download.failed.refresh=載入版本列表失敗，按一下此處重試。
 download.provider.mcbbs=我的世界中文論壇 (MCBBS, https://www.mcbbs.net/)
 download.provider.bmclapi=BMCLAPI (bangbang93，https://bmclapi2.bangbang93.com/)
 download.provider.mojang=官方伺服器 (OptiFine 自動安裝的下載來源是 BMCLAPI)
+download.provider.mcm=Minecraft Mirror(http://mcm.xgheaven.com)
 
 extension.bat=Windows 指令碼
 extension.mod=模組檔案

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -106,6 +106,7 @@ download.failed.refresh=加载版本列表失败，点击此处重试。
 download.provider.mcbbs=我的世界中文论坛 (MCBBS, https://www.mcbbs.net/)
 download.provider.bmclapi=BMCLAPI（bangbang93，https://bmclapi2.bangbang93.com/）
 download.provider.mojang=官方（OptiFine 自动安装使用 BMCLAPI 下载源）
+download.provider.mcm=Minecraft Mirror(http://mcm.xgheaven.com)
 
 extension.bat=Windows 脚本
 extension.mod=模组文件

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/OMCMAPIDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/OMCMAPIDownloadProvider.java
@@ -35,11 +35,12 @@ import java.io.File;
  */
 public class OMCMAPIDownloadProvider implements DownloadProvider {
     public static final Map<String, String> BUILTIN_HOST = new HashMap<String, String>() {{
+        // 理论上协议中是不允许出现改协议头的，但是如果不出现，URL 会解析失败，所以这里暂时添加上
         put("minecraft-meta", "https://launchermeta.mojang.com");
         put("minecraft-launcher", "https://launcher.mojang.com");
         put("minecraft-libraries", "https://libraries.minecraft.net");
         put("minecraft-resources", "https://resources.download.minecraft.net");
-        put("forge", "https://files.minecraftforge.net/maven");
+        put("forge", "https://files.minecraftforge.net");
         put("fabric-meta", "https://meta.fabricmc.net");
         put("fabric-maven", "https://maven.fabricmc.net");
     }};

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/OMCMAPIDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/OMCMAPIDownloadProvider.java
@@ -1,0 +1,151 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.download;
+
+import org.jackhuang.hmcl.download.fabric.FabricVersionList;
+import org.jackhuang.hmcl.download.forge.ForgeOMCMVersionList;
+import org.jackhuang.hmcl.download.game.GameVersionList;
+import org.jackhuang.hmcl.download.liteloader.LiteLoaderBMCLVersionList;
+import org.jackhuang.hmcl.download.optifine.OptiFineBMCLVersionList;
+import org.jackhuang.hmcl.util.io.NetworkUtils;
+
+import java.util.Set;
+import java.util.Map;
+import java.util.HashMap;
+import java.net.URL;
+import java.io.File;
+
+/**
+ * @author XGHeaven
+ */
+public class OMCMAPIDownloadProvider implements DownloadProvider {
+    public static final Map<String, String> BUILTIN_HOST = new HashMap<String, String>() {{
+        put("minecraft-meta", "https://launchermeta.mojang.com");
+        put("minecraft-launcher", "https://launcher.mojang.com");
+        put("minecraft-libraries", "https://libraries.minecraft.net");
+        put("minecraft-resources", "https://resources.download.minecraft.net");
+        put("forge", "https://files.minecraftforge.net/maven");
+        put("fabric-meta", "https://meta.fabricmc.net");
+        put("fabric-maven", "https://maven.fabricmc.net");
+    }};
+
+    public static String getUrlFromMap(String url, Map<String, String> mapper) throws Exception {
+        URL baseUrl = new URL(url);
+        for(Map.Entry<String, String> entry : mapper.entrySet()){
+            String source = entry.getKey();
+            String target = entry.getValue();
+            URL sourceUrl = new URL(source);
+            URL targetUrl = new URL(target);
+
+            // 匹配的过程中，不考虑协议
+            if (sourceUrl.getHost().equals(baseUrl.getHost()) && baseUrl.getPath().startsWith(sourceUrl.getPath())) {
+                String protocol = baseUrl.getProtocol();
+                String hostname = targetUrl.getHost();
+                String basePath = baseUrl.getPath();
+                String sourcePath = sourceUrl.getPath();
+                String targetPath = targetUrl.getPath();
+                if (sourcePath.endsWith("/")) {
+                    sourcePath = sourcePath.substring(0, sourcePath.length() - 1);
+                }
+                if (targetPath.endsWith("/")) {
+                    targetPath = targetPath.substring(0, targetPath.length() - 1);
+                }
+
+                String pathname = targetPath + basePath.substring(sourcePath.length());
+
+                if (targetUrl.getProtocol() != "") {
+                    // 如果镜像地址有协议的话，就使用镜像地址的
+                    protocol = targetUrl.getProtocol();
+                }
+
+                return new URL(protocol, hostname, pathname).toString();
+            }
+        }
+        return url;
+    }
+
+    private final GameVersionList game;
+    private final FabricVersionList fabric;
+    private final ForgeOMCMVersionList forge;
+    private final LiteLoaderBMCLVersionList liteLoader;
+    private final OptiFineBMCLVersionList optifine;
+    private final Map<String, String> mapper;
+
+    public OMCMAPIDownloadProvider(Map<String, String> originalMapper) {
+        String fallback = "https://bmclapi2.bangbang93.com";
+        Map<String, String> newMapper = new HashMap();
+
+        // 将预定义的 key 替换为正确的域名
+        for (Map.Entry<String, String> entry : originalMapper.entrySet()) {
+            String source = entry.getKey();
+            String target = entry.getValue();
+            newMapper.put(BUILTIN_HOST.containsKey(source) ? BUILTIN_HOST.get(source) : source, target);
+        }
+        System.out.println(newMapper);
+
+        this.mapper = newMapper;
+        this.game = new GameVersionList(this);
+        this.fabric = new FabricVersionList(this);
+        this.forge = new ForgeOMCMVersionList(this);
+        // 以下两个由 BMCLAPI 承担
+        this.liteLoader = new LiteLoaderBMCLVersionList(new BMCLAPIDownloadProvider(fallback));
+        this.optifine = new OptiFineBMCLVersionList(fallback);
+    }
+
+    @Override
+    public String getVersionListURL() {
+        return injectURL("https://launchermeta.mojang.com/mc/game/version_manifest.json");
+    }
+
+    @Override
+    public String getAssetBaseURL() {
+        return injectURL("http://resources.download.minecraft.net") + "/";
+    }
+
+    @Override
+    public VersionList<?> getVersionListById(String id) {
+        switch (id) {
+            case "game":
+                return game;
+            case "fabric":
+                return fabric;
+            case "forge":
+                return forge;
+            case "liteloader":
+                return liteLoader;
+            case "optifine":
+                return optifine;
+            default:
+                throw new IllegalArgumentException("Unrecognized version list id: " + id);
+        }
+    }
+
+    @Override
+    public String injectURL(String url) {
+        try {
+            return getUrlFromMap(url, mapper);
+        } catch(Exception e) {
+            return url;
+        }
+    }
+
+    @Override
+    public int getConcurrency() {
+        return Math.max(Runtime.getRuntime().availableProcessors() * 2, 6);
+    }
+}

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOMCMVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOMCMVersionList.java
@@ -87,8 +87,9 @@ public final class ForgeOMCMVersionList extends VersionList<ForgeRemoteVersion> 
                         String url = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/" + fullVersion + "/forge-" + fullVersion + "-installer.jar";
                         urls.add(downloadProvider.injectURL(url));
                         urls.add(url);
+                        String forgeVersion = StringUtils.substringAfter(fullVersion, "-");
                         versions.put(gameVersion, new ForgeRemoteVersion(
-                                gameVersion, fullVersion, urls));
+                                gameVersion, forgeVersion, urls));
                     }
                 } finally {
                     lock.writeLock().unlock();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOMCMVersionList.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOMCMVersionList.java
@@ -1,0 +1,188 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.download.forge;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+import org.jackhuang.hmcl.download.DownloadProvider;
+import org.jackhuang.hmcl.download.VersionList;
+import org.jackhuang.hmcl.task.GetTask;
+import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.Immutable;
+import org.jackhuang.hmcl.util.StringUtils;
+import org.jackhuang.hmcl.util.gson.JsonUtils;
+import org.jackhuang.hmcl.util.gson.Validation;
+import org.jackhuang.hmcl.util.io.NetworkUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+import static org.jackhuang.hmcl.util.Lang.mapOf;
+import static org.jackhuang.hmcl.util.Pair.pair;
+
+public final class ForgeOMCMVersionList extends VersionList<ForgeRemoteVersion> {
+    private static final String FORGE_META_URL = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.json";
+
+    private final DownloadProvider downloadProvider;
+
+    /**
+     * @param apiRoot API Root of BMCLAPI implementations
+     */
+    public ForgeOMCMVersionList(DownloadProvider downloadProvider) {
+        this.downloadProvider = downloadProvider;
+    }
+
+    @Override
+    public boolean hasType() {
+        return false;
+    }
+
+    @Override
+    public Task<?> loadAsync() {
+        throw new UnsupportedOperationException("ForgeBMCLVersionList does not support loading the entire Forge remote version list.");
+    }
+
+    @Override
+    public Task<?> refreshAsync() {
+        throw new UnsupportedOperationException("ForgeBMCLVersionList does not support loading the entire Forge remote version list.");
+    }
+
+    @Override
+    public Task<?> refreshAsync(String gameVersion) {
+        final GetTask task = new GetTask(NetworkUtils.toURL(downloadProvider.injectURL(ForgeOMCMVersionList.FORGE_META_URL)));
+        return new Task<Void>() {
+            @Override
+            public Collection<Task<?>> getDependents() {
+                return Collections.singleton(task);
+            }
+
+            @Override
+            public void execute() {
+                lock.writeLock().lock();
+
+                try {
+                    Map<String, List<String>> versionMaps = JsonUtils.GSON.fromJson(task.getResult(), new TypeToken<Map<String, List<String>>>() {
+                    }.getType());
+                    List<String> forgeVersions = versionMaps.get(gameVersion);
+                    versions.clear(gameVersion);
+                    if (forgeVersions == null) return;
+                    for (String fullVersion : forgeVersions) {
+                        List<String> urls = new ArrayList<>();
+                        String url = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/" + fullVersion + "/forge-" + fullVersion + "-installer.jar";
+                        urls.add(downloadProvider.injectURL(url));
+                        urls.add(url);
+                        versions.put(gameVersion, new ForgeRemoteVersion(
+                                gameVersion, fullVersion, urls));
+                    }
+                } finally {
+                    lock.writeLock().unlock();
+                }
+            }
+        };
+    }
+
+    @Override
+    public Optional<ForgeRemoteVersion> getVersion(String gameVersion, String remoteVersion) {
+        remoteVersion = StringUtils.substringAfter(remoteVersion, "-", remoteVersion);
+        return super.getVersion(gameVersion, remoteVersion);
+    }
+
+    @Immutable
+    public static final class ForgeVersion implements Validation {
+
+        private final String branch;
+        private final String mcversion;
+        private final String version;
+        private final List<File> files;
+
+        /**
+         * No-arg constructor for Gson.
+         */
+        @SuppressWarnings("unused")
+        public ForgeVersion() {
+            this(null, null, null, null);
+        }
+
+        public ForgeVersion(String branch, String mcversion, String version, List<File> files) {
+            this.branch = branch;
+            this.mcversion = mcversion;
+            this.version = version;
+            this.files = files;
+        }
+
+        @Nullable
+        public String getBranch() {
+            return branch;
+        }
+
+        @NotNull
+        public String getGameVersion() {
+            return mcversion;
+        }
+
+        @NotNull
+        public String getVersion() {
+            return version;
+        }
+
+        @NotNull
+        public List<File> getFiles() {
+            return files;
+        }
+
+        @Override
+        public void validate() throws JsonParseException {
+            if (files == null)
+                throw new JsonParseException("ForgeVersion files cannot be null");
+            if (version == null)
+                throw new JsonParseException("ForgeVersion version cannot be null");
+            if (mcversion == null)
+                throw new JsonParseException("ForgeVersion mcversion cannot be null");
+        }
+
+        @Immutable
+        public static final class File {
+            private final String format;
+            private final String category;
+            private final String hash;
+
+            public File() {
+                this("", "", "");
+            }
+
+            public File(String format, String category, String hash) {
+                this.format = format;
+                this.category = category;
+                this.hash = hash;
+            }
+
+            public String getFormat() {
+                return format;
+            }
+
+            public String getCategory() {
+                return category;
+            }
+
+            public String getHash() {
+                return hash;
+            }
+        }
+    }
+}


### PR DESCRIPTION
之前  #733 说的自定义 mirror 地址的方案，我花了一段时间去实现了一下，并在 HMCL 里面集成了。

相比 BMCLAPI 依靠 vps 的方案，依靠公有云对象存储的方案基本上完全可以跑满我本地 200M 的带宽，可以薅免费容量的对象存储还是挺香的。不过就是我本地开发的时候，经常跑着跑着就 OOM 了，但是构建之后就没问题，不清楚问题出在哪里。

不过就是只针对原版游戏、fabric、forge 实现了，Liteloader 以及 optfine 没有实现，主要是前者我平时用的实在是太少了，懒得弄了，后者我觉得算是一个模组，应该放在模组的同步里面。所以这两个暂时还是交给 BMCLAPI 来处理，以后可能顺便给 curseforge 也做一个 mirror，这样就能从头到尾的去加速的整合包的安装了。

理论上我设计了一个协议，只要符合这个协议的 mirror 都是可以无缝替换的，比较灵活一些。但是 UI 上的话我不太清楚应该怎么做比较好，就是在哪里可以弹出并输入配置，所以代码里面我就直接写死了，也当做我官方提供一个 mirror 了。

mirror 代码仓库：https://github.com/XGHeaven/mcm

因为 java 我不是很熟悉，所有有些写法是现查现用的，勿见怪，提出来我会改掉