### PR TITLE
fix: IllegalAccessError on Java 16

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -130,6 +130,9 @@ public class DefaultLauncher extends Launcher {
             if (options.getMinMemory() != null && options.getMinMemory() > 0)
                 res.add("-Xms" + options.getMinMemory() + "m");
 
+            if (options.getJava().getParsedVersion() >= JavaVersion.JAVA_16)
+                res.add("--illegal-access=permit");
+
             res.add("-Dfml.ignoreInvalidMinecraftCertificates=true");
             res.add("-Dfml.ignorePatchDiscrepancies=true");
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -96,6 +96,7 @@ public final class JavaVersion {
     public static final int JAVA_7 = 7;
     public static final int JAVA_8 = 8;
     public static final int JAVA_9 = 9;
+    public static final int JAVA_16 = 16;
 
     private static int parseVersion(String version) {
         Matcher matcher = VERSION.matcher(version);


### PR DESCRIPTION
Java 16 中由于 [JEP 403](https://openjdk.java.net/jeps/403)，默认 `illegal-access` 策略由 `permit` 调整为 `deny`，更强地封装了模块。

对于原版 Minecraft，这是无害的，因为它并未使用反射进行破坏封装的访问。但这种强封装会让很多 mod 无法在 Java 16 上工作，当尝试运行时会抛出 `IllegalAccessError`：
![一张来自群友的报错图片](https://user-images.githubusercontent.com/20694662/118398570-cebaf380-b68b-11eb-8733-c1f04a25521e.png)

默认添加 JVM 参数 `--illegal-access=permit` 可以避免这种迁移风险。

**风险**：`--illegal-access` 参数在未来某个时候可能会被移除，到那时应该为该默认参数添加版本上界。
