### PR TITLE
fix: `--illegal-access` will be removed in Java 17

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -130,7 +130,7 @@ public class DefaultLauncher extends Launcher {
             if (options.getMinMemory() != null && options.getMinMemory() > 0)
                 res.add("-Xms" + options.getMinMemory() + "m");
 
-            if (options.getJava().getParsedVersion() >= JavaVersion.JAVA_16)
+            if (options.getJava().getParsedVersion() == JavaVersion.JAVA_16)
                 res.add("--illegal-access=permit");
 
             res.add("-Dfml.ignoreInvalidMinecraftCertificates=true");


### PR DESCRIPTION
根据 [JEP 403](https://openjdk.java.net/jeps/403) 在今天早晨的更新，`--illegal-access` 将会在 Java 17 删除，所以将该选项适用版本限制在 Java 16 上。

保留自动添加该选项依然有促进迁移的作用，所以暂时不移除，希望尽早发布包含相关更改的 HMCL 新版本以推动 Java 版本的更新。