### PR TITLE
Use openjfx gradle plugin to dowload javafx

### DIFF
--- a/HMCL/build.gradle
+++ b/HMCL/build.gradle
@@ -10,6 +10,12 @@ buildscript {
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '7.0.0'
+    id 'org.openjfx.javafxplugin' version '0.0.9'
+}
+
+javafx {
+    version = "11.0.2"
+    modules = [ 'javafx.controls','javafx.fxml','javafx.web','javafx.swing']
 }
 
 import java.nio.file.FileSystems

--- a/HMCLCore/build.gradle
+++ b/HMCLCore/build.gradle
@@ -1,5 +1,11 @@
 plugins {
     id 'java-library'
+    id 'org.openjfx.javafxplugin' version '0.0.9'
+}
+
+javafx {
+    version = "11.0.2"
+    modules = [ 'javafx.controls','javafx.fxml','javafx.web','javafx.swing']
 }
 
 dependencies {


### PR DESCRIPTION
Don't rely on distro's javafx packages, which is probably not available. This PR makes HMCL's build environment more self-contained and easy to configure.