### PR TITLE
修复导出整合包的相关问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -36,6 +36,7 @@ import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
 import java.net.*;
 import java.nio.file.Paths;
@@ -160,10 +161,15 @@ public final class Launcher extends Application {
                     return null;
                 }
         } else {
-            File jarFile = new File(Launcher.class.getProtectionDomain().getCodeSource().getLocation().getPath());
-            String ext = FileUtils.getExtension(jarFile);
-            if ("jar".equals(ext) || "exe".equals(ext))
-                result.add(jarFile);
+            try {
+                File jarFile = new File(URLDecoder.decode(Launcher.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "UTF-8"));
+                String ext = FileUtils.getExtension(jarFile);
+                if ("jar".equals(ext) || "exe".equals(ext))
+                    result.add(jarFile);
+            } catch (UnsupportedEncodingException e) {
+                LOG.log(Level.WARNING, "Failed to decode jar path", e);
+                return null;
+            }
         }
         if (result.isEmpty())
             return null;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackFileSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackFileSelectionPage.java
@@ -129,7 +129,7 @@ public final class ModpackFileSelectionPage extends StackPane implements WizardP
 
     private void getFilesNeeded(CheckBoxTreeItem<String> node, String basePath, List<String> list) {
         if (node == null) return;
-        if (node.isSelected()) {
+        if (node.isSelected() || node.isIndeterminate()) {
             if (basePath.length() > "minecraft/".length())
                 list.add(StringUtils.substringAfter(basePath, "minecraft/"));
             for (TreeItem<String> child : node.getChildren()) {


### PR DESCRIPTION
* 修复运行在 Java 16 上，HMCL 本体在包含中文字符的路径中时，导出包含启动器的整合包报 `NoSuchFileException` 的问题。
* 修复导出整合包向导添加文件时，反选 CheckBoxTree 中的某个节点后，勾选它的子文件无法正常包含的问题。