### PR TITLE
refactor: use JarUtils.thisJar() where possible

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -1,6 +1,6 @@
 /*
  * Hello Minecraft! Launcher
- * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,18 +30,13 @@ import org.jackhuang.hmcl.upgrade.UpdateHandler;
 import org.jackhuang.hmcl.util.CrashReporter;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
-import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.awt.*;
-import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
 import java.net.*;
 import java.nio.file.Paths;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -146,35 +141,6 @@ public final class Launcher extends Application {
             Controllers.shutdown();
             Lang.executeDelayed(OperatingSystem::forceGC, TimeUnit.SECONDS, 5, true);
         });
-    }
-
-    public static List<File> getCurrentJarFiles() {
-        List<File> result = new LinkedList<>();
-        if (Launcher.class.getClassLoader() instanceof URLClassLoader) {
-            URL[] urls = ((URLClassLoader) Launcher.class.getClassLoader()).getURLs();
-            for (URL u : urls)
-                try {
-                    File f = new File(u.toURI());
-                    if (f.isFile() && (f.getName().endsWith(".exe") || f.getName().endsWith(".jar")))
-                        result.add(f);
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-        } else {
-            try {
-                File jarFile = new File(URLDecoder.decode(Launcher.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "UTF-8"));
-                String ext = FileUtils.getExtension(jarFile);
-                if ("jar".equals(ext) || "exe".equals(ext))
-                    result.add(jarFile);
-            } catch (UnsupportedEncodingException e) {
-                LOG.log(Level.WARNING, "Failed to decode jar path", e);
-                return null;
-            }
-        }
-        if (result.isEmpty())
-            return null;
-        else
-            return result;
     }
 
     public static final CrashReporter CRASH_REPORTER = new CrashReporter(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -1,6 +1,6 @@
 /*
  * Hello Minecraft! Launcher
- * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.export;
 
 import javafx.scene.Node;
-import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.mod.ModAdviser;
 import org.jackhuang.hmcl.mod.ModpackExportInfo;
 import org.jackhuang.hmcl.mod.mcbbs.McbbsModpackExportTask;
@@ -37,12 +36,14 @@ import org.jackhuang.hmcl.util.io.Zipper;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
+import static org.jackhuang.hmcl.util.io.JarUtils.thisJar;
 
 public final class ExportWizardProvider implements WizardProvider {
     private final Profile profile;
@@ -70,8 +71,8 @@ public final class ExportWizardProvider implements WizardProvider {
     }
 
     private Task<?> exportWithLauncher(String modpackType, ModpackExportInfo exportInfo, File modpackFile) {
-        List<File> launcherJar = Launcher.getCurrentJarFiles();
-        boolean packWithLauncher = exportInfo.isPackWithLauncher() && launcherJar != null;
+        Path launcherJar = thisJar().orElse(null);
+        boolean packWithLauncher = launcherJar != null;
         return new Task<Object>() {
             File tempModpack;
             Task<?> exportTask;
@@ -139,8 +140,7 @@ public final class ExportWizardProvider implements WizardProvider {
                     if (background_jpg.isFile())
                         zip.putFile(background_jpg, "background.jpg");
 
-                    for (File jar : launcherJar)
-                        zip.putFile(jar, jar.getName());
+                    zip.putFile(launcherJar, launcherJar.getFileName().toString());
                 }
             }
         };

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
@@ -1,6 +1,6 @@
 /*
  * Hello Minecraft! Launcher
- * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,6 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.FileChooser;
-import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.game.HMCLGameRepository;
@@ -61,6 +60,7 @@ import static org.jackhuang.hmcl.ui.export.ModpackTypeSelectionPage.MODPACK_TYPE
 import static org.jackhuang.hmcl.ui.export.ModpackTypeSelectionPage.MODPACK_TYPE_SERVER;
 import static org.jackhuang.hmcl.util.Lang.tryCast;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+import static org.jackhuang.hmcl.util.io.JarUtils.thisJar;
 
 public final class ModpackInfoPage extends Control implements WizardPage {
     private final WizardController controller;
@@ -101,8 +101,7 @@ public final class ModpackInfoPage extends Control implements WizardPage {
         launchArguments.set(versionSetting.getMinecraftArgs());
         javaArguments.set(versionSetting.getJavaArgs());
 
-        List<File> launcherJar = Launcher.getCurrentJarFiles();
-        canIncludeLauncher = launcherJar != null;
+        canIncludeLauncher = thisJar().isPresent();
 
         next.set(e -> onNext());
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/JarUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/JarUtils.java
@@ -1,6 +1,6 @@
 /*
  * Hello Minecraft! Launcher
- * Copyright (C) 2020  huangyuhui <huanghongxun2008@126.com> and contributors
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,12 +47,14 @@ public final class JarUtils {
 
         Path path;
         try {
-            path = Paths.get(url.toURI());
+            path = Paths.get(url.toURI()).toAbsolutePath();
         } catch (FileSystemNotFoundException | IllegalArgumentException | URISyntaxException e) {
             return Optional.empty();
         }
 
-        if (!Files.isRegularFile(path)) {
+        // When running HMCL from classes directory (instead of a JAR file),
+        // path will be a directory.
+        if (!Files.exists(path) || Files.isDirectory(path)) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
1. `JarUtils.thisJar()` 返回 JAR 或者 EXE 的绝对路径
   * 如果 HMCL 是从 classes 目录启动的（调试时），则返回空
2. 配置文件查找顺序（与之前相同）：
   1. 在 JAR 或 EXE 所在目录下查找，使用当前目录作为 fallback
   2. `hmcl.json` 文件
   3. `.hmcl.json` 文件
   4. 如果找不到，则创建配置文件（Windows 下为 `hmcl.json`，Linux、OSX 下为 `.hmcl.json`）
3. 删除 `Launcher.getCurrentJarFiles()`，导出整合包时用 `JarUtils.thisJar()` 获取启动器位置