### PR TITLE
修复在manifest中的因拼写问题造成的与文档不符的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackManifest.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackManifest.java
@@ -202,7 +202,7 @@ public class McbbsModpackManifest implements Validation {
     }
 
     public static final class Settings {
-        @SerializedName("install_modes")
+        @SerializedName("install_mods")
         private final boolean installMods;
 
         @SerializedName("install_resourcepack")


### PR DESCRIPTION
修复由于拼写错误导致HMCL导出的MCBBS整合包规范的整合包无法被其他工具和启动器识别的问题