### PR TITLE
HMCLLauncher: Search new Java registry location first

### DIFF
--- a/HMCLauncher/HMCL/java.cpp
+++ b/HMCLauncher/HMCL/java.cpp
@@ -5,10 +5,10 @@
 
 const Version JAVA_8(L"1.8"), JAVA_11(L"11");
 
-const LPCWSTR JDK_OLD = L"SOFTWARE\\JavaSoft\\Java Development Kit";
-const LPCWSTR JRE_OLD = L"SOFTWARE\\JavaSoft\\Java Runtime Environment";
 const LPCWSTR JDK_NEW = L"SOFTWARE\\JavaSoft\\JDK";
 const LPCWSTR JRE_NEW = L"SOFTWARE\\JavaSoft\\JRE";
+const LPCWSTR JDK_OLD = L"SOFTWARE\\JavaSoft\\Java Development Kit";
+const LPCWSTR JRE_OLD = L"SOFTWARE\\JavaSoft\\Java Runtime Environment";
 
 bool oldJavaFound = false;
 
@@ -71,10 +71,10 @@ bool FindJavaByRegistryKey(HKEY rootKey, LPCWSTR subKey, std::wstring& path) {
 }
 
 bool FindJavaInRegistry(std::wstring& path) {
-  return FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JDK_OLD, path) ||
-         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JRE_OLD, path) ||
-         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JDK_NEW, path) ||
-         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JRE_NEW, path);
+  return FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JDK_NEW, path) ||
+         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JRE_NEW, path) ||
+         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JDK_OLD, path) ||
+         FindJavaByRegistryKey(HKEY_LOCAL_MACHINE, JRE_OLD, path);
 }
 
 bool FindJava(std::wstring& path) {


### PR DESCRIPTION
新版本Java只存在于新注册表中，而旧Java版本不能自动补全JavaFX，但是AdoptOpenJDK等构建的Java8也不包含JavaFX

![image](https://user-images.githubusercontent.com/46394906/126490357-145d1076-ff24-4a19-8909-1e68d4eaabd4.png)


> 其实最好能做成环境变量强制指定Java但是我懒得写（小声bb