### PR TITLE
更新 GitHub Action 文件中的 JDK 版本至 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,11 @@ jobs:
     - uses: actions/checkout@v2
     - name: Checkout submodules
       run: git submodule update --init --recursive
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: '11'
         java-package: jdk+fx
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
使用 JDK 8 构建时，Gradle 还会再下载一个 JDK 11 用于构建 `JavaFXPatcher`。直接使用 JDK 11 可以略减少 GitHub Action 用时。