### PR TITLE
使用 GitHub Action 创建 GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and set HMCL version
+        run: |
+          export HMCL_VERSION=`echo ${{ github.ref }} | awk '{print substr($0,12)}'`
+          echo "HMCL_VERSION=$HMCL_VERSION" >> $GITHUB_ENV
+
+          if [ -z `echo $HMCL_VERSION | grep "^[0-9]\.[0-9]\.[0-9]\{3\}\$"` ]; then
+            exit 1
+          fi
+
+          echo "HMCL_BUILD_NUMBER=`echo $HMCL_VERSION | awk '{print substr($0,5)}'`" >> $GITHUB_ENV
+      - name: Download artifacts
+        run: |
+          wget "$DOWNLOAD_BASE_URL/HMCL-$HMCL_VERSION.exe"
+          wget "$DOWNLOAD_BASE_URL/HMCL-$HMCL_VERSION.exe.sha1"
+          wget "$DOWNLOAD_BASE_URL/HMCL-$HMCL_VERSION.jar"
+          wget "$DOWNLOAD_BASE_URL/HMCL-$HMCL_VERSION.jar.sha1"
+        env:
+          DOWNLOAD_BASE_URL: https://ci.huangyuhui.net/job/HMCL/${{ env.HMCL_BUILD_NUMBER }}/artifact/HMCL/build/libs
+      - name: Generate release note
+        run: |
+          echo "HMCL v$HMCL_VERSION" >> RELEASE_NOTE
+          echo "" >> RELEASE_NOTE
+          echo "The full changelogs can be found on the website: https://hmcl.huangyuhui.net/changelog/dev.html" >> RELEASE_NOTE
+          echo "Notice: changelogs are written in Chinese." >> RELEASE_NOTE
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: RELEASE_NOTE
+          files: |
+            HMCL-${{ env.HMCL_VERSION }}.exe
+            HMCL-${{ env.HMCL_VERSION }}.exe.sha1
+            HMCL-${{ env.HMCL_VERSION }}.jar
+            HMCL-${{ env.HMCL_VERSION }}.jar.sha1


### PR DESCRIPTION
当 push  `v*.*.***` 形式的 tag 时，使用 GitHub Action 自动生成一个对应的 Release，并从黄鱼的 CI 服务器中下载对应的 exe 和 jar 文件上传至 release 中。

该方案不需要黄鱼的 CI 服务器连接至 GitHub。

该方案下，创建一个 Release 的流程：

* 黄鱼使用原本的流程，在 CI 服务器上部署新开发版
* 在仓库中执行以下命令（以 `3.3.198` 版本为例）：
  ```
  git tag v3.3.198
  git push --tags
  ```

我已经创建了一个测试仓库，并用该仓库进行了测试，该流程运行良好。参见 https://github.com/Glavo/JustTestHMCL/releases/tag/v3.3.198

![image](https://user-images.githubusercontent.com/20694662/132535667-ad0a6540-17b0-4377-97dc-cf14f77d92ff.png)
