### PR TITLE
fix: `MEMINFO_PATTERN` is `null`

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -95,6 +95,8 @@ public enum OperatingSystem {
     private static final String[] INVALID_RESOURCE_BASENAMES;
     private static final String[] INVALID_RESOURCE_FULLNAMES;
 
+    private static final Pattern MEMINFO_PATTERN = Pattern.compile("^(?<key>.*?):\\s+(?<value>\\d+) kB?$");
+    
     static {
         String name = System.getProperty("os.name").toLowerCase(Locale.US);
         if (name.contains("win"))
@@ -131,8 +133,6 @@ public enum OperatingSystem {
             INVALID_RESOURCE_FULLNAMES = null;
         }
     }
-
-    private static final Pattern MEMINFO_PATTERN = Pattern.compile("^(?<key>.*?):\\s+(?<value>\\d+) kB?$");
 
     public static Optional<PhysicalMemoryStatus> getPhysicalMemoryStatus() {
         if (CURRENT_OS == LINUX) {


### PR DESCRIPTION
Fix
```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.jackhuang.hmcl.Metadata.<clinit>(Metadata.java:45)
	at org.jackhuang.hmcl.Main.main(Main.java:51)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.regex.Pattern.matcher(java.lang.CharSequence)" because "org.jackhuang.hmcl.util.platform.OperatingSystem.MEMINFO_PATTERN" is null
	at org.jackhuang.hmcl.util.platform.OperatingSystem.getPhysicalMemoryStatus(OperatingSystem.java:142)
	at org.jackhuang.hmcl.util.platform.OperatingSystem.<clinit>(OperatingSystem.java:109)
	... 2 more
```