### PR TITLE
在缺失 javafx.web 的环境使用替代方案

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -443,7 +443,7 @@ public final class FXUtils {
             stage.setTitle(title);
             stage.showAndWait();
         } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
-            LOG.log(Level.WARNING, "WebView missing or initialization failed, use JEditorPane replaced", e);
+            LOG.log(Level.WARNING, "WebView is missing or initialization failed, use JEditorPane replaced", e);
 
             SwingUtilities.invokeLater(() -> {
                 final JFrame frame = new JFrame(title);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -443,7 +443,7 @@ public final class FXUtils {
             stage.setTitle(title);
             stage.showAndWait();
         } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
-            LOG.log(Level.WARNING, "javafx.web is missing, use JEditorPane replaced", e);
+            LOG.log(Level.WARNING, "WebView missing or initialization failed, use JEditorPane replaced", e);
 
             SwingUtilities.invokeLater(() -> {
                 final JFrame frame = new JFrame(title);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -55,6 +55,7 @@ import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
@@ -461,6 +462,11 @@ public final class FXUtils {
                 Schedulers.defaultScheduler().execute(() -> {
                     final JEditorPane pane = new JEditorPane("text/html", content);
                     pane.setEditable(false);
+                    pane.addHyperlinkListener(event -> {
+                        if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                            openLink(event.getURL().toExternalForm());
+                        }
+                    });
                     SwingUtilities.invokeLater(() -> {
                         progressBar.setVisible(false);
                         frame.add(new JScrollPane(pane), BorderLayout.CENTER);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -25,9 +25,12 @@ import javafx.scene.web.WebView;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.ui.construct.DialogCloseEvent;
 
+import java.util.logging.Level;
+
 import static org.jackhuang.hmcl.Metadata.CHANGELOG_URL;
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
+import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public class UpgradeDialog extends JFXDialogLayout {
@@ -37,17 +40,23 @@ public class UpgradeDialog extends JFXDialogLayout {
         }
 
         {
+            String url = CHANGELOG_URL + config().getUpdateChannel().channelName + ".html";
             WebView webView = new WebView();
             webView.getEngine().setUserDataDirectory(Metadata.HMCL_DIRECTORY.toFile());
-            WebEngine engine = webView.getEngine();
-            engine.load(CHANGELOG_URL + config().getUpdateChannel().channelName);
-            engine.getLoadWorker().stateProperty().addListener((observable, oldValue, newValue) -> {
-                String url = engine.getLoadWorker().getMessage().trim();
-                if (!url.startsWith(CHANGELOG_URL)) {
-                    engine.getLoadWorker().cancel();
-                    FXUtils.openLink(url);
-                }
-            });
+            try {
+                WebEngine engine = webView.getEngine();
+                engine.load(CHANGELOG_URL + config().getUpdateChannel().channelName);
+                engine.getLoadWorker().stateProperty().addListener((observable, oldValue, newValue) -> {
+                    String viewURL = engine.getLoadWorker().getMessage().trim();
+                    if (!viewURL.startsWith(CHANGELOG_URL)) {
+                        engine.getLoadWorker().cancel();
+                        FXUtils.openLink(viewURL);
+                    }
+                });
+            } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
+                LOG.log(Level.WARNING, "WebView missing or initialization failed", e);
+                FXUtils.openLink(url);
+            }
             setBody(webView);
         }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -54,7 +54,7 @@ public class UpgradeDialog extends JFXDialogLayout {
                     }
                 });
             } catch (NoClassDefFoundError | UnsatisfiedLinkError e) {
-                LOG.log(Level.WARNING, "WebView missing or initialization failed", e);
+                LOG.log(Level.WARNING, "WebView is missing or initialization failed", e);
                 FXUtils.openLink(url);
             }
             setBody(webView);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/LocalModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/LocalModpackPage.java
@@ -43,12 +43,15 @@ import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 
+import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 
 import static javafx.beans.binding.Bindings.createBooleanBinding;
 import static org.jackhuang.hmcl.util.Lang.tryCast;
+import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public final class LocalModpackPage extends StackPane implements WizardPage {
@@ -156,10 +159,7 @@ public final class LocalModpackPage extends StackPane implements WizardPage {
     @FXML
     private void onDescribe() {
         if (manifest != null) {
-            WebStage stage = new WebStage();
-            stage.getWebView().getEngine().loadContent(manifest.getDescription());
-            stage.setTitle(i18n("modpack.description"));
-            stage.showAndWait();
+            FXUtils.showWebDialog(i18n("modpack.description"), manifest.getDescription());
         }
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/LocalModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/LocalModpackPage.java
@@ -34,7 +34,6 @@ import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
-import org.jackhuang.hmcl.ui.WebStage;
 import org.jackhuang.hmcl.ui.construct.MessageDialogPane.MessageType;
 import org.jackhuang.hmcl.ui.construct.RequiredValidator;
 import org.jackhuang.hmcl.ui.construct.SpinnerPane;
@@ -43,15 +42,12 @@ import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 
-import javax.swing.*;
-import java.awt.*;
 import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 
 import static javafx.beans.binding.Bindings.createBooleanBinding;
 import static org.jackhuang.hmcl.util.Lang.tryCast;
-import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 
 public final class LocalModpackPage extends StackPane implements WizardPage {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/RemoteModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/RemoteModpackPage.java
@@ -30,7 +30,6 @@ import org.jackhuang.hmcl.mod.server.ServerModpackManifest;
 import org.jackhuang.hmcl.setting.Profile;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
-import org.jackhuang.hmcl.ui.WebStage;
 import org.jackhuang.hmcl.ui.construct.MessageDialogPane;
 import org.jackhuang.hmcl.ui.construct.RequiredValidator;
 import org.jackhuang.hmcl.ui.construct.SpinnerPane;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/RemoteModpackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/RemoteModpackPage.java
@@ -130,10 +130,7 @@ public class RemoteModpackPage extends StackPane implements WizardPage {
 
     @FXML
     private void onDescribe() {
-        WebStage stage = new WebStage();
-        stage.getWebView().getEngine().loadContent(manifest.getDescription());
-        stage.setTitle(i18n("modpack.description"));
-        stage.showAndWait();
+        FXUtils.showWebDialog(i18n("modpack.description"), manifest.getDescription());
     }
 
     @Override

--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
@@ -257,14 +257,7 @@ public final class SelfDependencyPatcher {
         final JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 
-        final String chooserText;
-        if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX && Architecture.CURRENT == Architecture.ARM) {
-            chooserText = i18n("repositories.chooser.linux_arm32");
-        } else {
-            chooserText = i18n("repositories.chooser");
-        }
-
-        for (String line : chooserText.split("\n")) {
+        for (String line : i18n("repositories.chooser").split("\n")) {
             panel.add(new JLabel(line));
         }
 

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -572,7 +572,6 @@ repositories.custom=Custom Maven Repository (%s)
 repositories.maven_central=Universal (Maven Central)
 repositories.aliyun_mirror=Chinese mainland (Aliyun Maven Repository)
 repositories.chooser=JavaFX is missing. Do you want to automatically download and load JavaFX runtime components from web?\nSelect 'Yes' to download the JavaFX runtime components from the specified download source and start the HMCL, or select 'No' to exit the program.\nDownload Source:
-repositories.chooser.linux_arm32=JavaFX is missing. Do you want to automatically download and load JavaFX runtime components from web?\nSelect 'Yes' to download the JavaFX runtime components from the specified download source and start the HMCL, or select 'No' to exit the program.\nNote: Some components cannot be downloaded temporarily on Linux ARM32 platform, so HMCL may crash at runtime.\nDownload Source:
 repositories.chooser.title=Do you want to download JavaFX?
 
 resourcepack=Resource Pack

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -579,7 +579,6 @@ repositories.custom=自定義 Maven 倉庫（%s）
 repositories.maven_central=全球（Maven Central）
 repositories.aliyun_mirror=中國大陸（阿里雲 Maven 倉庫）
 repositories.chooser=缺少 JavaFX 運行環境。是否需要從網絡下載並加載 JavaFX 運行時組件？\n選擇“是”從指定下載源下載 JavaFX 運行時組件並啟動HMCL，選擇“否”退出程式。\n下載源：
-repositories.chooser.linux_arm32=缺少 JavaFX 運行環境。是否需要從網絡下載並加載 JavaFX 運行時組件？\n選擇“是”從指定下載源下載 JavaFX 運行時組件並啟動HMCL，選擇“否”退出程式。\n注意：Linux ARM32 平臺下暫時無法下載部分組件，運行時可能造成HMCL崩潰。\n下載源：
 repositories.chooser.title=是否下載 JavaFX？
 
 resourcepack=資源包

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -572,7 +572,6 @@ repositories.custom=自定义 Maven 仓库（%s）
 repositories.maven_central=全球（Maven Central）
 repositories.aliyun_mirror=中国大陆（阿里云 Maven 仓库）
 repositories.chooser=缺少 JavaFX 运行环境，是否需要从网络下载并加载 JavaFX 运行时组件？\n选择“是”从指定下载源下载 JavaFX 运行时组件并启动 HMCL，选择“否”退出程序。\n下载源：
-repositories.chooser.linux_arm32=缺少 JavaFX 运行环境，是否需要从网络下载并加载 JavaFX 运行时组件？\n选择“是”从指定下载源下载 JavaFX 运行时组件并启动 HMCL，选择“否”退出程序。\n注意：Linux ARM32 平台下暂时无法下载部分组件，运行时可能造成 HMCL 崩溃。\n下载源：
 repositories.chooser.title=是否下载 JavaFX？
 
 resourcepack=资源包


### PR DESCRIPTION
目前 HMCL 在展示整合包描述与更新日志时使用 `WebView`，因此强依赖  `javafx.web` 模块。

 `javafx.web` 模块存在体积过大以及部分平台（譬如 `linux-arm32` 上）没有完整支持的问题。

OpenJFX 不提供 `javafx.web` 模块 `linux-arm32-monocle` 的分发，同时 LibericaJDK ARM32 Full JDK 虽然携带了 `javafx.web` ，但是在我树莓派4b 的 Ubuntu ARM32 平台上使用时会抛出 `UnsatisfiedLinkError`。

<details>
  <summary>错误日志</summary>
[11:43:52] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:125)
[11:43:52] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:124)
[11:43:52] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:123)
[11:43:53] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:123)
[11:43:53] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:124)
[11:43:53] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.download.LocalModpackPage.<init>(LocalModpackPage.java:125)
[11:43:56] [org.jackhuang.hmcl.util.CrashReporter.uncaughtException/SEVERE] Uncaught exception in thread JavaFX Application Thread
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at javafx.fxml/javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1862)
	at javafx.fxml/javafx.fxml.FXMLLoader$ControllerMethodEventHandler.handle(FXMLLoader.java:1729)
	at javafx.base/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at javafx.base/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:234)
	at javafx.base/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at javafx.base/com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at javafx.base/com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.base/javafx.event.Event.fireEvent(Event.java:198)
	at javafx.graphics/javafx.scene.Scene$ClickGenerator.postProcess(Scene.java:3566)
	at javafx.graphics/javafx.scene.Scene$MouseHandler.process(Scene.java:3868)
	at javafx.graphics/javafx.scene.Scene.processMouseEvent(Scene.java:1854)
	at javafx.graphics/javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2587)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:409)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:299)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler.lambda$handleMouseEvent$2(GlassViewEventHandler.java:447)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:413)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:446)
	at javafx.graphics/com.sun.glass.ui.View.handleMouseEvent(View.java:556)
	at javafx.graphics/com.sun.glass.ui.View.notifyMouse(View.java:942)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at com.sun.javafx.reflect.Trampoline.invoke(MethodUtil.java:76)
	at jdk.internal.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at javafx.base/com.sun.javafx.reflect.MethodUtil.invoke(MethodUtil.java:273)
	at javafx.fxml/com.sun.javafx.fxml.MethodHelper.invoke(MethodHelper.java:83)
	at javafx.fxml/javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1859)
	... 41 more
Caused by: java.lang.UnsatisfiedLinkError: no jfxwebkit in java.library.path: /usr/java/packages/lib:/lib:/usr/lib
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2423)
	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:808)
	at java.base/java.lang.System.loadLibrary(System.java:1893)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:163)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:53)
	at javafx.web/com.sun.webkit.WebPage.lambda$static$0(WebPage.java:133)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:312)
	at javafx.web/com.sun.webkit.WebPage.<clinit>(WebPage.java:132)
	at javafx.web/javafx.scene.web.WebEngine.<init>(WebEngine.java:850)
	at javafx.web/javafx.scene.web.WebEngine.<init>(WebEngine.java:835)
	at javafx.web/javafx.scene.web.WebView.<init>(WebView.java:271)
	at org.jackhuang.hmcl.ui.WebStage.<init>(WebStage.java:36)
	at org.jackhuang.hmcl.ui.WebStage.<init>(WebStage.java:40)
	at org.jackhuang.hmcl.ui.download.LocalModpackPage.onDescribe(LocalModpackPage.java:159)
	... 52 more
[11:43:56] [org.jackhuang.hmcl.util.CrashReporter.uncaughtException/SEVERE] ---- Hello Minecraft! Crash Report ----
  Version: 3.4.dev-fd246b7
  Time: 2021-09-11 11:43:56
  Thread: Thread[JavaFX Application Thread,5,main]

  Content: 
    java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at javafx.fxml/javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1862)
	at javafx.fxml/javafx.fxml.FXMLLoader$ControllerMethodEventHandler.handle(FXMLLoader.java:1729)
	at javafx.base/com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at javafx.base/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:234)
	at javafx.base/com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at javafx.base/com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at javafx.base/com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at javafx.base/com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at javafx.base/com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.base/javafx.event.Event.fireEvent(Event.java:198)
	at javafx.graphics/javafx.scene.Scene$ClickGenerator.postProcess(Scene.java:3566)
	at javafx.graphics/javafx.scene.Scene$MouseHandler.process(Scene.java:3868)
	at javafx.graphics/javafx.scene.Scene.processMouseEvent(Scene.java:1854)
	at javafx.graphics/javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2587)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:409)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:299)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler.lambda$handleMouseEvent$2(GlassViewEventHandler.java:447)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:413)
	at javafx.graphics/com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:446)
	at javafx.graphics/com.sun.glass.ui.View.handleMouseEvent(View.java:556)
	at javafx.graphics/com.sun.glass.ui.View.notifyMouse(View.java:942)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:78)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at com.sun.javafx.reflect.Trampoline.invoke(MethodUtil.java:76)
	at jdk.internal.reflect.GeneratedMethodAccessor3.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at javafx.base/com.sun.javafx.reflect.MethodUtil.invoke(MethodUtil.java:273)
	at javafx.fxml/com.sun.javafx.fxml.MethodHelper.invoke(MethodHelper.java:83)
	at javafx.fxml/javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1859)
	... 41 more
Caused by: java.lang.UnsatisfiedLinkError: no jfxwebkit in java.library.path: /usr/java/packages/lib:/lib:/usr/lib
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2423)
	at java.base/java.lang.Runtime.loadLibrary0(Runtime.java:808)
	at java.base/java.lang.System.loadLibrary(System.java:1893)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibraryInternal(NativeLibLoader.java:163)
	at javafx.graphics/com.sun.glass.utils.NativeLibLoader.loadLibrary(NativeLibLoader.java:53)
	at javafx.web/com.sun.webkit.WebPage.lambda$static$0(WebPage.java:133)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:312)
	at javafx.web/com.sun.webkit.WebPage.<clinit>(WebPage.java:132)
	at javafx.web/javafx.scene.web.WebEngine.<init>(WebEngine.java:850)
	at javafx.web/javafx.scene.web.WebEngine.<init>(WebEngine.java:835)
	at javafx.web/javafx.scene.web.WebView.<init>(WebView.java:271)
	at org.jackhuang.hmcl.ui.WebStage.<init>(WebStage.java:36)
	at org.jackhuang.hmcl.ui.WebStage.<init>(WebStage.java:40)
	at org.jackhuang.hmcl.ui.download.LocalModpackPage.onDescribe(LocalModpackPage.java:159)
	... 52 more


-- System Details --
  Operating System: Linux 5.4.0-1042-raspi
  Java Version: 16.0.2, BellSoft
  Java VM Version: OpenJDK Server VM (mixed mode), BellSoft
  JVM Max Memory: 1073741824
  JVM Total Memory: 94371840
  JVM Free Memory: 26617984

[11:43:56] [org.jackhuang.hmcl.util.CrashReporter.checkThrowable/SEVERE] Your OS or Java environment may not be properly installed which may result in a crash, please check your Java Runtime Environment or your computer!
[11:44:16] [org.jackhuang.hmcl.ui.wizard.WizardController.onPrev/INFO] Navigating to ModpackSelectionPage@3fece3, pages: [ModpackSelectionPage@3fece3]
[11:44:17] [org.jackhuang.hmcl.ui.construct.Navigator.close/INFO] Closed page DecoratorWizardDisplayer@68aa1c[styleClass=content-background]
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initialize(VersionSettingsPage.java:532)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initialize(VersionSettingsPage.java:532)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initialize(VersionSettingsPage.java:532)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initJavaSubtitle(VersionSettingsPage.java:710)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$17/FINE] Executing task: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initJavaSubtitle(VersionSettingsPage.java:709)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initJavaSubtitle(VersionSettingsPage.java:709)
[11:44:22] [org.jackhuang.hmcl.ui.construct.Navigator.navigate/INFO] Navigate to LauncherSettingsPage@b46285
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initialize(VersionSettingsPage.java:532)
[11:44:22] [org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$27/FINER] Task finished: org.jackhuang.hmcl.ui.versions.VersionSettingsPage.initJavaSubtitle(VersionSettingsPage.java:710)
[11:44:24] [org.jackhuang.hmcl.setting.ConfigHolder.writeToConfig/INFO] Saving config
[11:44:24] [org.jackhuang.hmcl.setting.ConfigHolder.writeToConfig/INFO] Saving config
[11:44:24] [org.jackhuang.hmcl.setting.ConfigHolder.writeToConfig/INFO] Saving config
[11:44:24] [org.jackhuang.hmcl.setting.ConfigHolder.writeToConfig/INFO] Saving config
[11:44:38] [org.jackhuang.hmcl.ui.main.SettingsPage.lambda$onExportLogs$4/INFO] Exporting logs to /home/glavo/Downloads/hmcl-exported-logs-2021-09-11T11-44-38.log
</details>

另一方面，在分发包含 JRE 的完整整合包时，过于庞大（超过 20M，比 JavaFX 其他组件加起来还大）的 JavaFX 又会使整合包不必要地臃肿。

该 PR 允许 HMCL 在完全无 `javafx.web` 的环境或者 `javafx.web` 工作不正常的环境下使用替代方案实现完整功能：

* 整合包导入时，如果 `WebView` 无法使用，则使用 `JEditorPane` 显示模组信息。
* 显示更新日志时，如果 `WebView` 无法使用，则调用系统浏览器打开日志页面。

该 PR 同时修复了 Linux ARM32 上崩溃的问题，使 HMCL 完整支持了 Linux ARM32 平台。