### PR TITLE
修复读取MultiMC格式整合包时，整合包信息编码错误的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCInstanceConfiguration.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCInstanceConfiguration.java
@@ -24,7 +24,9 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -67,7 +69,7 @@ public final class MultiMCInstanceConfiguration {
 
     private MultiMCInstanceConfiguration(String defaultName, InputStream contentStream, MultiMCManifest mmcPack) throws IOException {
         Properties p = new Properties();
-        p.load(contentStream);
+        p.load(new InputStreamReader(contentStream, StandardCharsets.UTF_8));
 
         this.mmcPack = mmcPack;
 


### PR DESCRIPTION
在读取 `instance.cfg` 文件时用的 `Properties#load(InputStream)`，该方法总是以 `ISO 8859-1` 编码读取文件，所以会造成读取的内容乱码。