### PR TITLE
JEP 400：使用系统属性判断本机编码

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl.util.io;
 
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
 
 /**
  * This utility class consists of some util methods operating on InputStream/OutputStream.
@@ -31,6 +32,21 @@ public final class IOUtils {
     }
 
     public static final int DEFAULT_BUFFER_SIZE = 8 * 1024;
+
+    public static final Charset NATIVE_CHARSET;
+
+    static {
+        final String encoding = System.getProperty("native.encoding");
+        Charset charset = Charset.defaultCharset();
+        try {
+            if (encoding != null) {
+                charset = Charset.forName(encoding);
+            }
+        } catch (UnsupportedCharsetException e) {
+            e.printStackTrace();
+        }
+        NATIVE_CHARSET = charset;
+    }
 
     /**
      * Read all bytes to a buffer from given input stream. The stream will not be closed.


### PR DESCRIPTION
根据 [JEP 400](https://openjdk.java.net/jeps/400)，Java 18 中 `Charset.defaultCharset()` 默认为 `UTF-8`，而在 Java 17 中引入了新的系统属性 `native.encoding` 判断本机编码。

本 JEP 将检查 HMCL 中关于字符集与编码的应用，以适配 Java 18。