### PR TITLE
允许 HMCL 使用不同的架构的 JRE 启动 MC

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -63,6 +63,7 @@ public final class JavaVersion {
         return longVersion;
     }
 
+    @Deprecated
     public Platform getPlatform() {
         return platform;
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Platform.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Platform.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Type;
  * @author huangyuhui
  */
 @JsonAdapter(Platform.Serializer.class)
+@Deprecated
 public enum Platform {
     BIT_32("32"),
     BIT_64("64"),


### PR DESCRIPTION
由于跨架构转译器的出现与普及，同一平台运行不同的多个架构程序成为了可能，特别是 Mac OS 和 Windows 都实现了 AArch64 上的 x86-64 转译（Windows 还有 x86 转译），龙芯还将会实现 Linux LoongArch64 上的 x86/x86-64/AArch64/MISP64/RISC-V 转译，这对 HMCL 带来的新的挑战。

目前因为 x86-64 对 x86 的兼容性，HMCL 能够根据位数对架构进行简单判断，以提供基本的跨架构支持，但是这对于现在来说远远不够，因为用户完全可以以 x86/x86-64/AArch64 其中任意一个架构的 JDK 启动 HMCL，并启动另一个架构上的 MC，HMCL 目前无法应对这种场景。

该 PR 目的是彻底解决跨架构启动 MC 问题，目前想到的几个分解小目标：

- [ ] 彻底弃用 `org.jackhuang.hmcl.util.platform.Platform`，将依赖于判断位数的程序迁移至判断平台。
- [ ] `JavaVersion` 应判断对应 JDK 的平台，而不只是位数。
- [ ] 为不同平台隔离本机库文件夹（默认将本机库放到 `.minecraft/versions/<版本名>/natives-<系统名>-<架构名>` 下）。

该 PR 尚未完成（这几天应该能做完）。