### PR TITLE
修复 Windows 上 HMCL 位于网络位置时的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -25,6 +25,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,7 +37,8 @@ import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public final class ConfigHolder {
 
-    private ConfigHolder() {}
+    private ConfigHolder() {
+    }
 
     public static final String CONFIG_FILENAME = "hmcl.json";
     public static final String CONFIG_FILENAME_LINUX = ".hmcl.json";
@@ -84,9 +86,11 @@ public final class ConfigHolder {
         }
 
         if (!Files.isWritable(configLocation)) {
-            // the config cannot be saved
-            // throw up the error now to prevent further data loss
-            throw new IOException("Config at " + configLocation + " is not writable");
+            if (configLocation.getFileSystem() != FileSystems.getDefault() || !configLocation.toFile().setExecutable(true)) {
+                // the config cannot be saved
+                // throw up the error now to prevent further data loss
+                throw new IOException("Config at " + configLocation + " is not writable");
+            }
         }
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -366,8 +366,6 @@ public final class FileUtils {
             throw new IOException("Source '" + srcFile + "' exists but is a directory");
         Path parentFile = destFile.getParent();
         Files.createDirectories(parentFile);
-        if (Files.exists(destFile) && !Files.isWritable(destFile))
-            throw new IOException("Destination '" + destFile + "' exists but is read-only");
 
         Files.copy(srcFile, destFile, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
     }


### PR DESCRIPTION
`Files.isWritable` 对于网络位置的实现不正确，即使在可写入的情况下也会返回 `false`，导致 HMCL 位于网络位置时认为自身无法写入配置文件而出错。