### PR TITLE
搜索更多 Java 安装

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -246,6 +246,8 @@ public final class JavaVersion {
                         javaExecutables.add(listDirectory(programFiles.get().resolve("AdoptOpenJDK")).map(JavaVersion::getExecutable));
                         javaExecutables.add(listDirectory(programFiles.get().resolve("Zulu")).map(JavaVersion::getExecutable));
                         javaExecutables.add(listDirectory(programFiles.get().resolve("Microsoft")).map(JavaVersion::getExecutable));
+                        javaExecutables.add(listDirectory(programFiles.get().resolve("Eclipse Foundation")).map(JavaVersion::getExecutable));
+                        javaExecutables.add(listDirectory(programFiles.get().resolve("Semeru")).map(JavaVersion::getExecutable));
                     }
                 }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -249,6 +249,17 @@ public final class JavaVersion {
                     }
                 }
 
+                final Optional<Path> programFilesX86 = FileUtils.tryGetPath(Optional.ofNullable(System.getenv("ProgramFiles(x86)")).orElse("C:\\Program Files (x86)"));
+                if (programFilesX86.isPresent()) {
+                    final Path runtimeDir = programFilesX86.get().resolve("Minecraft Launcher").resolve("runtime");
+                    javaExecutables.add(Stream.of(
+                            runtimeDir.resolve("jre-legacy").resolve("windows-x64").resolve("jre-legacy"),
+                            runtimeDir.resolve("jre-legacy").resolve("windows-x86").resolve("jre-legacy"),
+                            runtimeDir.resolve("java-runtime-alpha").resolve("windows-x64").resolve("java-runtime-alpha"),
+                            runtimeDir.resolve("java-runtime-alpha").resolve("windows-x86").resolve("java-runtime-alpha")
+                    ).map(JavaVersion::getExecutable));
+                }
+
                 if (System.getenv("PATH") != null) {
                     javaExecutables.add(Arrays.stream(System.getenv("PATH").split(";")).flatMap(path -> Lang.toStream(FileUtils.tryGetPath(path, "java.exe"))));
                 }
@@ -267,6 +278,15 @@ public final class JavaVersion {
                 if (System.getenv("HMCL_JRES") != null) {
                     javaExecutables.add(Arrays.stream(System.getenv("HMCL_JRES").split(":")).flatMap(path -> Lang.toStream(FileUtils.tryGetPath(path, "bin", "java"))));
                 }
+
+                final Optional<Path> home = FileUtils.tryGetPath(System.getProperty("user.home", ""));
+                if (home.isPresent()) {
+                    final Path runtimeDir = home.get().resolve(".minecraft").resolve("runtime");
+                    javaExecutables.add(Stream.of(
+                            runtimeDir.resolve("jre-legacy").resolve("linux").resolve("jre-legacy"),
+                            runtimeDir.resolve("java-runtime-alpha").resolve("linux").resolve("java-runtime-alpha")
+                    ).map(JavaVersion::getExecutable));
+                }
                 break;
 
             case OSX:
@@ -278,6 +298,7 @@ public final class JavaVersion {
                         .map(JavaVersion::getExecutable));
                 javaExecutables.add(Stream.of(Paths.get("/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java")));
                 javaExecutables.add(Stream.of(Paths.get("/Applications/Xcode.app/Contents/Applications/Application Loader.app/Contents/MacOS/itms/java/bin/java")));
+                javaExecutables.add(Stream.of(Paths.get("/Library/Application Support/minecraft/runtime/jre-x64/jre.bundle/Contents/Home/bin/java")));
                 if (System.getenv("PATH") != null) {
                     javaExecutables.add(Arrays.stream(System.getenv("PATH").split(":")).flatMap(path -> Lang.toStream(FileUtils.tryGetPath(path, "java"))));
                 }


### PR DESCRIPTION
* AdoptOpenJDK 已经迁移，现在分别由 Eclipse 和 IBM 提供 HotSpot 与 J9 的版本：
  * Eclipse Temurin 默认安装在 `%ProgramFiles%\Eclipse Foundation` 中
  * IBM Semeru 默认安装在  `%ProgramFiles%\Semeru` 中
* 支持搜索 Minecraft 官方启动器所安装的 Java 8 以及 Java 16