### PR TITLE
fix #1054: 避免长路径破坏 UI 布局

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MultiFileItem.java
@@ -29,6 +29,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -128,7 +129,8 @@ public class MultiFileItem<T> extends ComponentSublist {
         protected final T data;
 
         public Option(String title, T data) {
-            this.title = title; this.data = data;
+            this.title = title;
+            this.data = data;
         }
 
         public T getData() {
@@ -160,7 +162,14 @@ public class MultiFileItem<T> extends ComponentSublist {
             pane.setLeft(left);
 
             if (StringUtils.isNotBlank(subtitle)) {
-                Label right = new Label(subtitle);
+                Optional<String> shortSubtitle = StringUtils.truncate(subtitle);
+                Label right;
+                if (shortSubtitle.isPresent()) {
+                    right = new Label(shortSubtitle.get());
+                    right.setTooltip(new Tooltip(subtitle));
+                } else {
+                    right = new Label(subtitle);
+                }
                 BorderPane.setAlignment(right, Pos.CENTER_RIGHT);
                 right.setWrapText(true);
                 right.getStyleClass().add("subtitle-label");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -21,10 +21,7 @@ import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -243,6 +240,17 @@ public final class StringUtils {
             result.append(ch);
         }
         return result.toString();
+    }
+
+    public static int MAX_SHORT_STRING_LENGTH = 77;
+
+    public static Optional<String> truncate(String str) {
+        if (str.length() <= MAX_SHORT_STRING_LENGTH) {
+            return Optional.empty();
+        }
+
+        final int halfLength = (MAX_SHORT_STRING_LENGTH - 5) / 2;
+        return Optional.of(str.substring(0, halfLength) + " ... " + str.substring(str.length() - halfLength));
     }
 
     /**


### PR DESCRIPTION
将过长的字符串缩短显示，使用 Tooltip 展示完整路径。