### PR TITLE
Check writable on jarfile for conifg init

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -108,7 +108,7 @@ public final class ConfigHolder {
         try {
             Path jarPath = Paths.get(ConfigHolder.class.getProtectionDomain().getCodeSource().getLocation()
                     .toURI()).toAbsolutePath();
-            if (Files.isRegularFile(jarPath)) {
+            if (Files.isRegularFile(jarPath) && Files.isWritable(jarPath)) {
                 jarPath = jarPath.getParent();
                 exePath = jarPath;
 


### PR DESCRIPTION
In the case, the jar is at read only place but working directory is ok  
like the jar is installed to /usr/local/share/HMCL  

Although, It can be solved by touch the hmcl.json before start jar,  
I think fallback to working directory in code is better.   