### PR TITLE
Support XDG_Base_Directory environment variable

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl;
 
 import org.jackhuang.hmcl.util.io.JarUtils;
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.nio.file.Path;
@@ -52,6 +53,10 @@ public final class Metadata {
         String home = System.getProperty("user.home", ".");
         if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX) {
             // to fulfill XDG standard.
+            String xdgCache = System.getenv("XDG_CACHE_HOME");
+            if (StringUtils.isNotBlank(xdgCache)) {
+                return Paths.get(xdgCache, "hmcl");
+            }
             return Paths.get(home, ".cache", "hmcl");
         }
         return OperatingSystem.getWorkingDirectory("hmcl");


### PR DESCRIPTION
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
> $XDG_CACHE_HOME defines the base directory relative to which user-specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.
