### PR TITLE
Fix #1153: On Windows, the 'classpath' environment variable in the context overrides the 'CLASSPATH'

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -416,7 +416,12 @@ public class DefaultLauncher extends Launcher {
             }
             String appdata = options.getGameDir().getAbsoluteFile().getParent();
             if (appdata != null) builder.environment().put("APPDATA", appdata);
-            if (classpath != null) builder.environment().put("CLASSPATH", classpath);
+            if (classpath != null) {
+                builder.environment().put("CLASSPATH", classpath);
+                // Fix #1153: On Windows, the 'classpath' environment variable in the context overrides the 'CLASSPATH'
+                // Environment variables on Windows are not case-sensitive; The lowercase 'classpath' overwrites any other case.
+                builder.environment().put("classpath", classpath);
+            }
             builder.environment().putAll(getEnvVars());
             process = builder.start();
         } catch (IOException e) {


### PR DESCRIPTION
Windows 平台上，上下文中的 `classpath` 环境变量会覆盖这里设置的 `CLASSPATH` 环境变量，导致启动失败。手动设置 `classpath` 可以解决这个问题。

（PS：实际上 JVM 只识别全大写的 `CLASSPATH`，所以大写的 `CLASSPATH` 依然需要设置，否则 Linux/Mac OS 上无法启动）