### PR TITLE
略微优化日志记录性能

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -19,11 +19,10 @@ package org.jackhuang.hmcl.util;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.text.SimpleDateFormat;
+import java.text.MessageFormat;
 import java.util.Date;
 import java.util.logging.*;
 
@@ -93,21 +92,19 @@ public final class Logging {
     private static final class DefaultFormatter extends Formatter {
 
         static final DefaultFormatter INSTANCE = new DefaultFormatter();
-        private final SimpleDateFormat format = new SimpleDateFormat("HH:mm:ss");
+        private static final MessageFormat format = new MessageFormat("[{0,date,HH:mm:ss}] [{1}.{2}/{3}] {4}\n");
 
         @Override
         public String format(LogRecord record) {
-            String date = format.format(new Date(record.getMillis()));
-            String log = String.format("[%s] [%s.%s/%s] %s%n",
-                    date, record.getSourceClassName(), record.getSourceMethodName(),
-                    record.getLevel().getName(), record.getMessage()
-            );
-            ByteArrayOutputStream builder = new ByteArrayOutputStream();
+            String log = format.format(new Object[]{
+                    new Date(record.getMillis()),
+                    record.getSourceClassName(), record.getSourceMethodName(), record.getLevel().getName(),
+                    record.getMessage()
+            });
             if (record.getThrown() != null)
-                try (PrintWriter writer = new PrintWriter(builder)) {
-                    record.getThrown().printStackTrace(writer);
-                }
-            return log + builder.toString();
+                log += StringUtils.getStackTrace(record.getThrown());
+
+            return log;
         }
 
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -17,6 +17,8 @@
  */
 package org.jackhuang.hmcl.util;
 
+import org.jackhuang.hmcl.util.io.IOUtils;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,7 +36,7 @@ public final class Logging {
     }
 
     public static final Logger LOG = Logger.getLogger("HMCL");
-    private static ByteArrayOutputStream storedLogs = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream storedLogs = new ByteArrayOutputStream(IOUtils.DEFAULT_BUFFER_SIZE);
 
     public static void start(Path logFolder) {
         LOG.setLevel(Level.ALL);
@@ -100,7 +102,7 @@ public final class Logging {
                     new Date(record.getMillis()),
                     record.getSourceClassName(), record.getSourceMethodName(), record.getLevel().getName(),
                     record.getMessage()
-            });
+            }, new StringBuffer(128), null).toString();
             if (record.getThrown() != null)
                 log += StringUtils.getStackTrace(record.getThrown());
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -19,9 +19,7 @@ package org.jackhuang.hmcl.util;
 
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -37,13 +35,11 @@ public final class StringUtils {
     }
 
     public static String getStackTrace(Throwable throwable) {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(512);
-        try {
-            throwable.printStackTrace(new PrintStream(stream, false, "UTF-8"));
-            return stream.toString("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new InternalError(e);
+        StringWriter stringWriter = new StringWriter(512);
+        try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            throwable.printStackTrace(printWriter);
         }
+        return stringWriter.toString();
     }
 
     public static String getStackTrace(StackTraceElement[] elements) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -37,7 +37,7 @@ public final class StringUtils {
     }
 
     public static String getStackTrace(Throwable throwable) {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(512);
         try {
             throwable.printStackTrace(new PrintStream(stream, false, "UTF-8"));
             return stream.toString("UTF-8");


### PR DESCRIPTION
* 简化写法，让代码更明晰。
* `String.format` 每次都需要创建新的 `Formatter` 对象并解析格式字符串，`MessageFormat` 能省下这部分开销。
   我用随机数据简单构建了一个 JMH 基准测试，测试中新的写法性能提高了 13%。理论上来说，内存占用也会略微降低。
   
   ```
   Benchmark           Mode  Cnt       Score       Error  Units
   FormatTest.testNew  avgt   15  779298.327 ± 54418.431  ns/op
   FormatTest.testOld  avgt   15  896317.988 ± 31569.280  ns/op
   ```
* 仅在必要的时候创建 `ByteArrayOutputStream`。
* 调整部分缓冲的默认容量以减少内存分配。

