### PR TITLE
默认情况下禁止 Minecraft 日志记录中使用 Message Pattern Lookup

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -178,6 +178,9 @@ public class DefaultLauncher extends Launcher {
 
             res.addDefault("-Dfml.ignoreInvalidMinecraftCertificates=", "true");
             res.addDefault("-Dfml.ignorePatchDiscrepancies=", "true");
+
+            // Fix RCE vulnerability of log4j2
+            res.addDefault("-Dlog4j2.formatMsgNoLookups=", "true");
         }
 
         Proxy proxy = options.getProxy();


### PR DESCRIPTION
Log4j2 被爆出严重的 RCE 漏洞，至目前为止所有版本都存在该漏洞。对于 Minecraft 服务器来说，任何成员只需要向服务器发送带有特定内容的字符串，即可控制服务器执行攻击者想要的命令。（修复见 apache/logging-log4j2#608）

由于 Minecraft 客户端允许在网络上共享世界，充当服务器的角色，此时也可能遭受类似的攻击。

该攻击是基于 Log4j2 中的 Message Pattern Lookup 功能，Minecraft 中似乎没有使用该功能，默认禁用它可以避免玩家在使用客户端开服时遭受对应攻击。