### PR TITLE
Fix #1148: 判断 Minecraft 控制台输出编码

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -50,8 +50,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import static org.jackhuang.hmcl.util.Lang.mapOf;
+import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.Pair.pair;
 
 /**
@@ -115,6 +117,19 @@ public class DefaultLauncher extends Launcher {
         res.add(options.getJava().getBinary().toString());
 
         res.addAllWithoutParsing(options.getJavaArguments());
+
+        Charset encoding = OperatingSystem.NATIVE_CHARSET;
+
+        // After Java 17, file.encoding does not affect console encoding
+        if (options.getJava().getParsedVersion() <= JavaVersion.JAVA_17) {
+            try {
+                String fileEncoding = res.addDefault("-Dfile.encoding=", encoding.name());
+                if (fileEncoding != null)
+                    encoding = Charset.forName(fileEncoding.substring("-Dfile.encoding=".length()));
+            } catch (Throwable ex) {
+                LOG.log(Level.WARNING, "Bad file encoding", ex);
+            }
+        }
 
         // JVM Args
         if (!options.isNoGeneratedJVMArgs()) {
@@ -281,7 +296,7 @@ public class DefaultLauncher extends Launcher {
         res.addAllWithoutParsing(Arguments.parseStringArguments(options.getGameArguments(), configuration));
 
         res.removeIf(it -> getForbiddens().containsKey(it) && getForbiddens().get(it).get());
-        return new Command(res, tempNativeFolder);
+        return new Command(res, tempNativeFolder, encoding);
     }
 
     public Map<String, Boolean> getFeatures() {
@@ -469,7 +484,7 @@ public class DefaultLauncher extends Launcher {
 
         ManagedProcess p = new ManagedProcess(process, rawCommandLine, classpath);
         if (listener != null)
-            startMonitors(p, listener, daemon);
+            startMonitors(p, listener, command.encoding, daemon);
         return p;
     }
 
@@ -635,17 +650,17 @@ public class DefaultLauncher extends Launcher {
             throw new ExecutionPolicyLimitException();
     }
 
-    private void startMonitors(ManagedProcess managedProcess, ProcessListener processListener, boolean isDaemon) {
+    private void startMonitors(ManagedProcess managedProcess, ProcessListener processListener, Charset encoding, boolean isDaemon) {
         processListener.setProcess(managedProcess);
         Thread stdout = Lang.thread(new StreamPump(managedProcess.getProcess().getInputStream(), it -> {
             processListener.onLog(it, Optional.ofNullable(Log4jLevel.guessLevel(it)).orElse(Log4jLevel.INFO));
             managedProcess.addLine(it);
-        }, OperatingSystem.NATIVE_CHARSET), "stdout-pump", isDaemon);
+        }, encoding), "stdout-pump", isDaemon);
         managedProcess.addRelatedThread(stdout);
         Thread stderr = Lang.thread(new StreamPump(managedProcess.getProcess().getErrorStream(), it -> {
             processListener.onLog(it, Log4jLevel.ERROR);
             managedProcess.addLine(it);
-        }, OperatingSystem.NATIVE_CHARSET), "stderr-pump", isDaemon);
+        }, encoding), "stderr-pump", isDaemon);
         managedProcess.addRelatedThread(stderr);
         managedProcess.addRelatedThread(Lang.thread(new ExitWaiter(managedProcess, Arrays.asList(stdout, stderr), processListener::onExit), "exit-waiter", isDaemon));
     }
@@ -653,10 +668,12 @@ public class DefaultLauncher extends Launcher {
     private static final class Command {
         final CommandBuilder commandLine;
         final Path tempNativeFolder;
+        final Charset encoding;
 
-        Command(CommandBuilder commandBuilder, Path tempNativeFolder) {
+        Command(CommandBuilder commandBuilder, Path tempNativeFolder, Charset encoding) {
             this.commandLine = commandBuilder;
             this.tempNativeFolder = tempNativeFolder;
+            this.encoding = encoding;
         }
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
@@ -83,33 +83,33 @@ public final class CommandBuilder {
         return this;
     }
 
-    public CommandBuilder addDefault(String opt) {
+    public String addDefault(String opt) {
         for (Item item : raw) {
             if (item.arg.equals(opt)) {
-                return this;
+                return item.arg;
             }
         }
         raw.add(new Item(opt, true));
-        return this;
+        return null;
     }
 
-    public CommandBuilder addDefault(String opt, String value) {
+    public String addDefault(String opt, String value) {
         for (Item item : raw) {
             if (item.arg.startsWith(opt)) {
                 LOG.info("Default option '" + opt + value + "' is suppressed by '" + item.arg + "'");
-                return this;
+                return item.arg;
             }
         }
         raw.add(new Item(opt + value, true));
-        return this;
+        return null;
     }
 
-    public CommandBuilder addUnstableDefault(String opt, boolean value) {
+    public String addUnstableDefault(String opt, boolean value) {
         for (Item item : raw) {
             final Matcher matcher = UNSTABLE_BOOLEAN_OPTION_PATTERN.matcher(item.arg);
             if (matcher.matches()) {
                 if (matcher.group("key").equals(opt)) {
-                    return this;
+                    return item.arg;
                 }
             }
         }
@@ -119,21 +119,21 @@ public final class CommandBuilder {
         } else {
             raw.add(new Item("-XX:-" + opt, true));
         }
-        return this;
+        return null;
     }
 
-    public CommandBuilder addUnstableDefault(String opt, String value) {
+    public String addUnstableDefault(String opt, String value) {
         for (Item item : raw) {
             final Matcher matcher = UNSTABLE_OPTION_PATTERN.matcher(item.arg);
             if (matcher.matches()) {
                 if (matcher.group("key").equals(opt)) {
-                    return this;
+                    return item.arg;
                 }
             }
         }
 
         raw.add(new Item("-XX:" + opt + "=" + value, true));
-        return this;
+        return null;
     }
 
     public boolean removeIf(Predicate<String> pred) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -112,6 +112,7 @@ public final class JavaVersion {
     public static final int JAVA_8 = 8;
     public static final int JAVA_9 = 9;
     public static final int JAVA_16 = 16;
+    public static final int JAVA_17 = 17;
 
     private static int parseVersion(String version) {
         Matcher matcher = VERSION.matcher(version);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -112,15 +113,25 @@ public enum OperatingSystem {
     private static final Pattern MEMINFO_PATTERN = Pattern.compile("^(?<key>.*?):\\s+(?<value>\\d+) kB?$");
 
     static {
-        String nativeEncoding = System.getProperty("native.encoding", System.getProperty("sun.jnu.encoding"));
+        String nativeEncoding = System.getProperty("native.encoding");
+        String hmclNativeEncoding = System.getProperty("hmcl.native.encoding");
         Charset nativeCharset = Charset.defaultCharset();
 
-        if (nativeEncoding != null) {
-            try {
-                nativeCharset = Charset.forName(nativeEncoding);
-            } catch (UnsupportedCharsetException e) {
-                e.printStackTrace();
+        try {
+            if (hmclNativeEncoding != null) {
+                nativeCharset = Charset.forName(hmclNativeEncoding);
+            } else {
+                if (nativeEncoding != null && !nativeEncoding.equalsIgnoreCase(nativeCharset.name())) {
+                    nativeCharset = Charset.forName(nativeEncoding);
+                }
+                if (nativeCharset == StandardCharsets.UTF_8 || nativeCharset == StandardCharsets.US_ASCII) {
+                    nativeCharset = StandardCharsets.UTF_8;
+                } else if ("GBK".equalsIgnoreCase(nativeCharset.name())) {
+                    nativeCharset = Charset.forName("GB18030");
+                }
             }
+        } catch (UnsupportedCharsetException e) {
+            e.printStackTrace();
         }
         NATIVE_CHARSET = nativeCharset;
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -124,9 +124,10 @@ public enum OperatingSystem {
                 if (nativeEncoding != null && !nativeEncoding.equalsIgnoreCase(nativeCharset.name())) {
                     nativeCharset = Charset.forName(nativeEncoding);
                 }
+
                 if (nativeCharset == StandardCharsets.UTF_8 || nativeCharset == StandardCharsets.US_ASCII) {
                     nativeCharset = StandardCharsets.UTF_8;
-                } else if ("GBK".equalsIgnoreCase(nativeCharset.name())) {
+                } else if ("GBK".equalsIgnoreCase(nativeCharset.name()) || "GB2312".equalsIgnoreCase(nativeCharset.name())) {
                     nativeCharset = Charset.forName("GB18030");
                 }
             }

--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ Make sure you have Java installed with JavaFX 8 at least. Liberica full JDK 8 or
 |`-Dhmcl.update_source.override=<url>`|Override the update source.|
 |`-Dhmcl.authlibinjector.location=<path>`|Use specified authlib-injector (instead of downloading one).|
 |`-Dhmcl.openjfx.repo=<maven repository url>`|Add custom maven repository for download OpenJFX.|
+|`-Dhmcl.native.encoding=<encoding>`|Override the native encoding.|
 |`-Dhmcl.microsoft.auth.id=<App ID>`|Override Microsoft OAuth App ID.|
 |`-Dhmcl.microsoft.auth.secret=<App Secret>`|Override Microsoft OAuth App secret.|


### PR DESCRIPTION
Java 17 以及更早版本中，`file.encoding` 会影响 Minecraft 的控制台编码，HMCL 应该识别该选项。