### PR TITLE
安全地保存配置文件

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -30,7 +30,6 @@ import java.nio.file.*;
 import java.util.Map;
 import java.util.logging.Level;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public final class ConfigHolder {
@@ -175,7 +174,7 @@ public final class ConfigHolder {
     private static void writeToConfig(String content) throws IOException {
         LOG.info("Saving config");
         synchronized (configLocation) {
-            Files.write(configLocation, content.getBytes(UTF_8));
+            FileUtils.saveSafely(configLocation, content);
         }
     }
 
@@ -219,7 +218,7 @@ public final class ConfigHolder {
     private static void writeToGlobalConfig(String content) throws IOException {
         LOG.info("Saving global config");
         synchronized (GLOBAL_CONFIG_PATH) {
-            Files.write(GLOBAL_CONFIG_PATH, content.getBytes(UTF_8));
+            FileUtils.saveSafely(GLOBAL_CONFIG_PATH, content);
         }
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -20,6 +20,7 @@ package org.jackhuang.hmcl.util.io;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -36,7 +37,6 @@ import java.util.function.Predicate;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- *
  * @author huang
  */
 public final class FileUtils {
@@ -424,5 +424,25 @@ public final class FileUtils {
         } catch (InvalidPathException e) {
             return Optional.empty();
         }
+    }
+
+    public static Path tmpSaveFile(Path file) {
+        return file.toAbsolutePath().resolveSibling("." + file.getFileName().toString() + ".tmp");
+    }
+
+    public static void saveSafely(Path file, String content) throws IOException {
+        Path tmpFile = tmpSaveFile(file);
+        try (BufferedWriter writer = Files.newBufferedWriter(tmpFile, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
+            writer.write(content);
+        }
+
+        try {
+            if (Files.exists(file) && Files.getAttribute(file, "dos:hidden") == Boolean.TRUE) {
+                Files.setAttribute(tmpFile, "dos:hidden", true);
+            }
+        } catch (Throwable ignored) {
+        }
+
+        Files.move(tmpFile, file, StandardCopyOption.REPLACE_EXISTING);
     }
 }


### PR DESCRIPTION
目前通过覆写保存 Config，过程中遇到断电、USB 断开等突发情况会损坏已有的配置，通过写入临时文件再重命名覆盖避免该风险。