### PR TITLE
支持离线安装 OptiFine 1.17.1 H1 之后的版本

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineInstallTask.java
@@ -229,6 +229,7 @@ public final class OptiFineInstallTask extends Task<Version> {
         try (FileSystem fs = CompressingUtils.createReadOnlyZipFileSystem(installer)) {
             Path configClass = fs.getPath("Config.class");
             if (!Files.exists(configClass)) configClass = fs.getPath("net/optifine/Config.class");
+            if (!Files.exists(configClass)) configClass = fs.getPath("notch/net/optifine/Config.class");
             if (!Files.exists(configClass)) throw new IOException("Unrecognized installer");
             ConstantPool pool = ConstantPoolScanner.parse(Files.readAllBytes(configClass), ConstantType.UTF8);
             List<String> constants = new ArrayList<>();


### PR DESCRIPTION
 OptiFine 1.17.1 H1 开始，`net.optifine.Config` 移动至文件夹 `notch/net/optifine` 内。