### PR TITLE
允许用户通过 JVM 参数显式启用 Message Lookup

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -180,15 +180,15 @@ public class DefaultLauncher extends Launcher {
 
             res.addDefault("-Dfml.ignoreInvalidMinecraftCertificates=", "true");
             res.addDefault("-Dfml.ignorePatchDiscrepancies=", "true");
-
-            // Fix RCE vulnerability of log4j2
-            res.addDefault("-Dlog4j2.formatMsgNoLookups=", "true");
-            res.addDefault("-Djava.rmi.server.useCodebaseOnly=", "true");
-            res.addDefault("-Dcom.sun.jndi.rmi.object.trustURLCodebase=", "false");
-            res.addDefault("-Dcom.sun.jndi.cosnaming.object.trustURLCodebase=", "false");
         }
 
-        if (isUsingLog4j()) {
+        // Fix RCE vulnerability of log4j2
+        res.addDefault("-Djava.rmi.server.useCodebaseOnly=", "true");
+        res.addDefault("-Dcom.sun.jndi.rmi.object.trustURLCodebase=", "false");
+        res.addDefault("-Dcom.sun.jndi.cosnaming.object.trustURLCodebase=", "false");
+
+        String formatMsgNoLookups = res.addDefault("-Dlog4j2.formatMsgNoLookups=", "true");
+        if (!"-Dlog4j2.formatMsgNoLookups=false".equals(formatMsgNoLookups) && isUsingLog4j()) {
             res.addDefault("-Dlog4j.configurationFile=", getLog4jConfigurationFile().getAbsolutePath());
         }
 
@@ -476,7 +476,6 @@ public class DefaultLauncher extends Launcher {
     private Map<String, String> getEnvVars() {
         String versionName = Optional.ofNullable(options.getVersionName()).orElse(version.getId());
         Map<String, String> env = new HashMap<>();
-        env.put("LOG4J_FORMAT_MSG_NO_LOOKUPS", "true");
         env.put("INST_NAME", versionName);
         env.put("INST_ID", versionName);
         env.put("INST_DIR", repository.getVersionRoot(version.getId()).getAbsolutePath());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
@@ -83,33 +83,33 @@ public final class CommandBuilder {
         return this;
     }
 
-    public CommandBuilder addDefault(String opt) {
+    public String addDefault(String opt) {
         for (Item item : raw) {
             if (item.arg.equals(opt)) {
-                return this;
+                return item.arg;
             }
         }
         raw.add(new Item(opt, true));
-        return this;
+        return null;
     }
 
-    public CommandBuilder addDefault(String opt, String value) {
+    public String addDefault(String opt, String value) {
         for (Item item : raw) {
             if (item.arg.startsWith(opt)) {
                 LOG.info("Default option '" + opt + value + "' is suppressed by '" + item.arg + "'");
-                return this;
+                return item.arg;
             }
         }
         raw.add(new Item(opt + value, true));
-        return this;
+        return null;
     }
 
-    public CommandBuilder addUnstableDefault(String opt, boolean value) {
+    public String addUnstableDefault(String opt, boolean value) {
         for (Item item : raw) {
             final Matcher matcher = UNSTABLE_BOOLEAN_OPTION_PATTERN.matcher(item.arg);
             if (matcher.matches()) {
                 if (matcher.group("key").equals(opt)) {
-                    return this;
+                    return item.arg;
                 }
             }
         }
@@ -119,21 +119,21 @@ public final class CommandBuilder {
         } else {
             raw.add(new Item("-XX:-" + opt, true));
         }
-        return this;
+        return null;
     }
 
-    public CommandBuilder addUnstableDefault(String opt, String value) {
+    public String addUnstableDefault(String opt, String value) {
         for (Item item : raw) {
             final Matcher matcher = UNSTABLE_OPTION_PATTERN.matcher(item.arg);
             if (matcher.matches()) {
                 if (matcher.group("key").equals(opt)) {
-                    return this;
+                    return item.arg;
                 }
             }
         }
 
         raw.add(new Item("-XX:" + opt + "=" + value, true));
-        return this;
+        return null;
     }
 
     public boolean removeIf(Predicate<String> pred) {

--- a/HMCLCore/src/main/resources/assets/game/log4j2-1.12.xml
+++ b/HMCLCore/src/main/resources/assets/game/log4j2-1.12.xml
@@ -22,7 +22,6 @@
             </filters>
             <AppenderRef ref="SysOut"/>
             <AppenderRef ref="File"/>
-            <AppenderRef ref="ServerGuiConsole"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/HMCLCore/src/main/resources/assets/game/log4j2-1.7.xml
+++ b/HMCLCore/src/main/resources/assets/game/log4j2-1.7.xml
@@ -23,7 +23,6 @@
             </filters>
             <AppenderRef ref="SysOut"/>
             <AppenderRef ref="File"/>
-            <AppenderRef ref="ServerGuiConsole"/>
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
为了安全起见，HMCL 现在默认禁用 Message Lookup，但这会破坏部分版本 Forge 以及某些 mod 的日志输出。

#1228 之后安全性已经被再次加强，所以可以略微放开对 Message Lookup 的限制：

* 默认情况下，依然禁用 Message Lookup；
* 当用户显式添加了 `-Dlog4j2.formatMsgNoLookups=false` JVM 参数时，启用 Message Lookup；
* JNDI Lookup 始终被禁用。