### PR TITLE
fix: Bootstrap launcher version does not need to be displayed on GameCrashWindow

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -315,13 +315,15 @@ public class GameCrashWindow extends Stage {
                 moddedPane.setAlignment(Pos.CENTER_LEFT);
 
                 for (LibraryAnalyzer.LibraryType type : LibraryAnalyzer.LibraryType.values()) {
-                    analyzer.getVersion(type).ifPresent(ver -> {
-                        TwoLineListItem item = new TwoLineListItem();
-                        item.getStyleClass().setAll("two-line-item-second-large");
-                        item.setTitle(i18n("install.installer." + type.getPatchId()));
-                        item.setSubtitle(ver);
-                        moddedPane.getChildren().add(item);
-                    });
+                    if (!type.getPatchId().isEmpty()) {
+                        analyzer.getVersion(type).ifPresent(ver -> {
+                            TwoLineListItem item = new TwoLineListItem();
+                            item.getStyleClass().setAll("two-line-item-second-large");
+                            item.setTitle(i18n("install.installer." + type.getPatchId()));
+                            item.setSubtitle(ver);
+                            moddedPane.getChildren().add(item);
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
…CrashWindow