### PR TITLE
尽可能减少使用 LinkedList

### DIFF
--- a/HMCL/src/main/java/moe/mickey/minecraft/skin/fx/SkinAnimation.java
+++ b/HMCL/src/main/java/moe/mickey/minecraft/skin/fx/SkinAnimation.java
@@ -3,8 +3,8 @@ package moe.mickey.minecraft.skin.fx;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 
 public class SkinAnimation {
@@ -14,7 +14,7 @@ public class SkinAnimation {
 
     @Deprecated
     public SkinAnimation() {
-        this.transitions = new LinkedList<>();
+        this.transitions = new ArrayList<>();
     }
 
     public SkinAnimation(int weight, SkinTransition... transitions) {

--- a/HMCL/src/main/java/moe/mickey/minecraft/skin/fx/SkinAnimationPlayer.java
+++ b/HMCL/src/main/java/moe/mickey/minecraft/skin/fx/SkinAnimationPlayer.java
@@ -2,14 +2,15 @@ package moe.mickey.minecraft.skin.fx;
 
 import javafx.animation.AnimationTimer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 
 public class SkinAnimationPlayer {
 
     protected final Random random = new Random();
-    protected LinkedList<SkinAnimation> animations = new LinkedList<>();
+    protected List<SkinAnimation> animations = new ArrayList<>();
     protected SkinAnimation playing;
     protected boolean running;
     protected int weightedSum = 0;
@@ -28,7 +29,7 @@ public class SkinAnimationPlayer {
                 }
                 playing = tmp;
                 if (playing == null && animations.size() > 0)
-                    playing = animations.getLast();
+                    playing = animations.get(animations.size() - 1);
                 if (playing != null) {
                     playing.playFromStart();
                     lastPlayTime = now;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLModpackInstallTask.java
@@ -33,7 +33,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class HMCLModpackInstallTask extends Task<Void> {
@@ -42,8 +42,8 @@ public final class HMCLModpackInstallTask extends Task<Void> {
     private final HMCLGameRepository repository;
     private final DefaultDependencyManager dependency;
     private final Modpack modpack;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
+    private final List<Task<?>> dependents = new ArrayList<>(4);
 
     public HMCLModpackInstallTask(Profile profile, File zipFile, Modpack modpack, String name) {
         dependency = profile.getDependency();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profiles.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profiles.java
@@ -26,8 +26,8 @@ import org.jackhuang.hmcl.event.EventBus;
 import org.jackhuang.hmcl.event.RefreshedVersionsEvent;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -204,7 +204,7 @@ public final class Profiles {
         return selectedVersion.get();
     }
 
-    private static final List<Consumer<Profile>> versionsListeners = new LinkedList<>();
+    private static final List<Consumer<Profile>> versionsListeners = new ArrayList<>(4);
 
     public static void registerVersionsListener(Consumer<Profile> listener) {
         Profile profile = getSelectedProfile();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackFileSelectionPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackFileSelectionPage.java
@@ -35,7 +35,7 @@ import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -147,7 +147,7 @@ public final class ModpackFileSelectionPage extends StackPane implements WizardP
 
     @FXML
     private void onNext() {
-        LinkedList<String> list = new LinkedList<>();
+        ArrayList<String> list = new ArrayList<>();
         getFilesNeeded(rootNode, "minecraft", list);
         controller.getSettings().put(MODPACK_FILE_SELECTION, list);
         controller.onFinish();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -95,7 +95,7 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
                 synchronized (ModListPage.this) {
                     runInFX(() -> loadingProperty().set(true));
                     modManager.refreshMods();
-                    return new LinkedList<>(modManager.getMods());
+                    return new ArrayList<>(modManager.getMods());
                 }
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -118,10 +118,12 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
         chooser.getExtensionFilters().setAll(new FileChooser.ExtensionFilter(i18n("extension.mod"), "*.jar", "*.zip", "*.litemod"));
         List<File> res = chooser.showOpenMultipleDialog(Controllers.getStage());
 
-        // It's guaranteed that succeeded and failed are thread safe here.
-        List<String> succeeded = new LinkedList<>();
-        List<String> failed = new LinkedList<>();
         if (res == null) return;
+
+        // It's guaranteed that succeeded and failed are thread safe here.
+        List<String> succeeded = new ArrayList<>(res.size());
+        List<String> failed = new ArrayList<>();
+
         Task.runAsync(() -> {
             for (File file : res) {
                 try {
@@ -135,7 +137,7 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
                 }
             }
         }).withRunAsync(Schedulers.javafx(), () -> {
-            List<String> prompt = new LinkedList<>();
+            List<String> prompt = new ArrayList<>(1);
             if (!succeeded.isEmpty())
                 prompt.add(i18n("mods.add.success", String.join(", ", succeeded)));
             if (!failed.isEmpty())

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MaintainTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MaintainTask.java
@@ -283,7 +283,7 @@ public class MaintainTask extends Task<Version> {
     public static Version unique(Version version) {
         List<Library> libraries = new ArrayList<>();
 
-        SimpleMultimap<String, Integer> multimap = new SimpleMultimap<String, Integer>(HashMap::new, LinkedList::new);
+        SimpleMultimap<String, Integer> multimap = new SimpleMultimap<String, Integer>(HashMap::new, ArrayList::new);
 
         for (Library library : version.getLibraries()) {
             String id = library.getGroupId() + ":" + library.getArtifactId();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricAPIInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricAPIInstallTask.java
@@ -24,8 +24,8 @@ import org.jackhuang.hmcl.task.Task;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -38,7 +38,7 @@ public final class FabricAPIInstallTask extends Task<Version> {
     private final DefaultDependencyManager dependencyManager;
     private final Version version;
     private final FabricAPIRemoteVersion remote;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     public FabricAPIInstallTask(DefaultDependencyManager dependencyManager, Version version, FabricAPIRemoteVersion remoteVersion) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/fabric/FabricInstallTask.java
@@ -45,7 +45,7 @@ public final class FabricInstallTask extends Task<Version> {
     private final Version version;
     private final FabricRemoteVersion remote;
     private final GetTask launchMetaTask;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     public FabricInstallTask(DefaultDependencyManager dependencyManager, Version version, FabricRemoteVersion remoteVersion) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeNewInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeNewInstallTask.java
@@ -182,8 +182,8 @@ public class ForgeNewInstallTask extends Task<Version> {
     private final DefaultGameRepository gameRepository;
     private final Version version;
     private final Path installer;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(1);
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     private ForgeNewInstallProfile profile;
     private List<Processor> processors;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOldInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeOldInstallTask.java
@@ -29,7 +29,7 @@ import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.*;
 import java.nio.file.Path;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -41,7 +41,7 @@ public class ForgeOldInstallTask extends Task<Version> {
     private final Version version;
     private final Path installer;
     private final String selfVersion;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     ForgeOldInstallTask(DefaultDependencyManager dependencyManager, Version version, String selfVersion, Path installer) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetDownloadTask.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -50,8 +50,8 @@ public final class GameAssetDownloadTask extends Task<Void> {
     private final AssetIndexInfo assetIndexInfo;
     private final Path assetIndexFile;
     private final boolean integrityCheck;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(1);
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     /**
      * Constructor.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetIndexDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetIndexDownloadTask.java
@@ -33,7 +33,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -49,7 +49,7 @@ public final class GameAssetIndexDownloadTask extends Task<Void> {
     private final AbstractDependencyManager dependencyManager;
     private final Version version;
     private final boolean forceDownloading;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     /**
      * Constructor.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameDownloadTask.java
@@ -25,8 +25,8 @@ import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.CacheRepository;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -37,7 +37,7 @@ public final class GameDownloadTask extends Task<Void> {
     private final DefaultDependencyManager dependencyManager;
     private final String gameVersion;
     private final Version version;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     public GameDownloadTask(DefaultDependencyManager dependencyManager, String gameVersion, Version version) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameInstallTask.java
@@ -23,9 +23,9 @@ import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.MINECRAFT;
@@ -37,7 +37,7 @@ public class GameInstallTask extends Task<Version> {
     private final Version version;
     private final GameRemoteVersion remote;
     private final VersionJsonDownloadTask downloadTask;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     public GameInstallTask(DefaultDependencyManager dependencyManager, Version version, GameRemoteVersion remoteVersion) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameLibrariesTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameLibrariesTask.java
@@ -29,7 +29,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -45,7 +45,7 @@ public final class GameLibrariesTask extends Task<Void> {
     private final Version version;
     private final boolean integrityCheck;
     private final List<Library> libraries;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     /**
      * Constructor.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameVerificationFixTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameVerificationFixTask.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -41,7 +41,7 @@ public final class GameVerificationFixTask extends Task<Void> {
     private final DefaultDependencyManager dependencyManager;
     private final String gameVersion;
     private final Version version;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     public GameVerificationFixTask(DefaultDependencyManager dependencyManager, String gameVersion, Version version) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/VersionJsonDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/VersionJsonDownloadTask.java
@@ -24,8 +24,8 @@ import org.jackhuang.hmcl.task.GetTask;
 import org.jackhuang.hmcl.task.Task;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -35,8 +35,8 @@ import java.util.List;
 public final class VersionJsonDownloadTask extends Task<String> {
     private final String gameVersion;
     private final DefaultDependencyManager dependencyManager;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(1);
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
     private final VersionList<?> gameVersionList;
 
     public VersionJsonDownloadTask(String gameVersion, DefaultDependencyManager dependencyManager) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/liteloader/LiteLoaderInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/liteloader/LiteLoaderInstallTask.java
@@ -23,9 +23,9 @@ import org.jackhuang.hmcl.game.*;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.Lang;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -38,8 +38,8 @@ public final class LiteLoaderInstallTask extends Task<Version> {
     private final DefaultDependencyManager dependencyManager;
     private final Version version;
     private final LiteLoaderRemoteVersion remote;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     public LiteLoaderInstallTask(DefaultDependencyManager dependencyManager, Version version, LiteLoaderRemoteVersion remoteVersion) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/optifine/OptiFineInstallTask.java
@@ -56,8 +56,8 @@ public final class OptiFineInstallTask extends Task<Version> {
     private final Version version;
     private final OptiFineRemoteVersion remote;
     private final Path installer;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(0);
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
     private Path dest;
 
     private final Library optiFineLibrary;
@@ -131,7 +131,7 @@ public final class OptiFineInstallTask extends Task<Version> {
                 !LibraryAnalyzer.BOOTSTRAP_LAUNCHER_MAIN.equals(originalMainClass))
             throw new UnsupportedInstallationException(UnsupportedInstallationException.UNSUPPORTED_LAUNCH_WRAPPER);
 
-        List<Library> libraries = new LinkedList<>();
+        List<Library> libraries = new ArrayList<>(4);
         libraries.add(optiFineLibrary);
 
         FileUtils.copyFile(dest, gameRepository.getLibraryFile(version, optiFineInstallerLibrary).toPath());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/Arguments.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/Arguments.java
@@ -110,7 +110,7 @@ public final class Arguments {
     public static final List<Argument> DEFAULT_GAME_ARGUMENTS;
 
     static {
-        List<Argument> jvm = new LinkedList<>();
+        List<Argument> jvm = new ArrayList<>(8);
         jvm.add(new RuledArgument(Collections.singletonList(new CompatibilityRule(CompatibilityRule.Action.ALLOW, new OSRestriction(OperatingSystem.WINDOWS))), Collections.singletonList("-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump")));
         jvm.add(new RuledArgument(Collections.singletonList(new CompatibilityRule(CompatibilityRule.Action.ALLOW, new OSRestriction(OperatingSystem.WINDOWS, "^10\\."))), Arrays.asList("-Dos.name=Windows 10", "-Dos.version=10.0")));
         jvm.add(new StringArgument("-Djava.library.path=${natives_directory}"));
@@ -120,7 +120,7 @@ public final class Arguments {
         jvm.add(new StringArgument("${classpath}"));
         DEFAULT_JVM_ARGUMENTS = Collections.unmodifiableList(jvm);
 
-        List<Argument> game = new LinkedList<>();
+        List<Argument> game = new ArrayList<>(1);
         game.add(new RuledArgument(Collections.singletonList(new CompatibilityRule(CompatibilityRule.Action.ALLOW, null, Collections.singletonMap("has_custom_resolution", true))), Arrays.asList("--width", "${resolution_width}", "--height", "${resolution_height}")));
         DEFAULT_GAME_ARGUMENTS = Collections.unmodifiableList(game);
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ExtractRules.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ExtractRules.java
@@ -17,8 +17,8 @@
  */
 package org.jackhuang.hmcl.game;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -36,7 +36,7 @@ public final class ExtractRules {
     }
 
     public ExtractRules(List<String> exclude) {
-        this.exclude = new LinkedList<>(exclude);
+        this.exclude = new ArrayList<>(exclude);
     }
 
     public List<String> getExclude() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -261,7 +261,7 @@ public class DefaultLauncher extends Launcher {
 
         res.add(version.getMainClass());
 
-        res.addAll(Arguments.parseStringArguments(version.getMinecraftArguments().map(StringUtils::tokenize).orElseGet(LinkedList::new), configuration));
+        res.addAll(Arguments.parseStringArguments(version.getMinecraftArguments().map(StringUtils::tokenize).orElseGet(ArrayList::new), configuration));
 
         Map<String, Boolean> features = getFeatures();
         version.getArguments().map(Arguments::getGame).ifPresent(arguments -> res.addAll(Arguments.parseArguments(arguments, configuration, features)));

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/MinecraftInstanceTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/MinecraftInstanceTask.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.jackhuang.hmcl.util.DigestUtils.digest;
@@ -57,7 +57,7 @@ public final class MinecraftInstanceTask<T> extends Task<ModpackConfiguration<T>
 
     @Override
     public void execute() throws Exception {
-        List<ModpackConfiguration.FileInformation> overrides = new LinkedList<>();
+        List<ModpackConfiguration.FileInformation> overrides = new ArrayList<>();
 
         try (FileSystem fs = CompressingUtils.readonly(zipFile.toPath()).setEncoding(encoding).build()) {
             Path root = fs.getPath(subDirectory);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseCompletionTask.java
@@ -32,8 +32,8 @@ import org.jackhuang.hmcl.util.io.NetworkUtils;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,7 +52,7 @@ public final class CurseCompletionTask extends Task<Void> {
     private final ModManager modManager;
     private final String version;
     private CurseManifest manifest;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     private final AtomicBoolean allNameKnown = new AtomicBoolean(true);
     private final AtomicInteger finished = new AtomicInteger(0);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseInstallTask.java
@@ -33,8 +33,8 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -52,8 +52,8 @@ public final class CurseInstallTask extends Task<Void> {
     private final String name;
     private final File run;
     private final ModpackConfiguration<CurseManifest> config;
-    private final List<Task<?>> dependents = new LinkedList<>();
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(4);
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
 
     /**
      * Constructor.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseManifestMinecraft.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseManifestMinecraft.java
@@ -23,8 +23,8 @@ import org.jackhuang.hmcl.util.Immutable;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.Validation;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -47,7 +47,7 @@ public final class CurseManifestMinecraft implements Validation {
 
     public CurseManifestMinecraft(String gameVersion, List<CurseManifestModLoader> modLoaders) {
         this.gameVersion = gameVersion;
-        this.modLoaders = new LinkedList<>(modLoaders);
+        this.modLoaders = new ArrayList<>(modLoaders);
     }
 
     public String getGameVersion() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
@@ -63,7 +63,7 @@ public class McbbsModpackCompletionTask extends CompletableFutureTask<Void> {
     private final File configurationFile;
     private ModpackConfiguration<McbbsModpackManifest> configuration;
     private McbbsModpackManifest manifest;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     private final AtomicBoolean allNameKnown = new AtomicBoolean(true);
     private final AtomicInteger finished = new AtomicInteger(0);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackLocalInstallTask.java
@@ -33,7 +33,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,8 +47,8 @@ public class McbbsModpackLocalInstallTask extends Task<Void> {
     private final boolean update;
     private final DefaultGameRepository repository;
     private final MinecraftInstanceTask<McbbsModpackManifest> instanceTask;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(2);
+    private final List<Task<?>> dependents = new ArrayList<>(4);
 
     public McbbsModpackLocalInstallTask(DefaultDependencyManager dependencyManager, File zipFile, Modpack modpack, McbbsModpackManifest manifest, String name) {
         this.dependencyManager = dependencyManager;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackRemoteInstallTask.java
@@ -29,8 +29,8 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 public class McbbsModpackRemoteInstallTask extends Task<Void> {
@@ -38,8 +38,8 @@ public class McbbsModpackRemoteInstallTask extends Task<Void> {
     private final String name;
     private final DefaultDependencyManager dependency;
     private final DefaultGameRepository repository;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
+    private final List<Task<?>> dependents = new ArrayList<>(1);
     private final McbbsModpackManifest manifest;
 
     public McbbsModpackRemoteInstallTask(DefaultDependencyManager dependencyManager, McbbsModpackManifest manifest, String name) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/multimc/MultiMCModpackInstallTask.java
@@ -40,7 +40,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,8 +54,8 @@ public final class MultiMCModpackInstallTask extends Task<Void> {
     private final MultiMCInstanceConfiguration manifest;
     private final String name;
     private final DefaultGameRepository repository;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
+    private final List<Task<?>> dependents = new ArrayList<>(4);
 
     public MultiMCModpackInstallTask(DefaultDependencyManager dependencyManager, File zipFile, Modpack modpack, MultiMCInstanceConfiguration manifest, String name) {
         this.zipFile = zipFile;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
@@ -53,7 +53,7 @@ public class ServerModpackCompletionTask extends Task<Void> {
     private ModpackConfiguration<ServerModpackManifest> manifest;
     private GetTask dependent;
     private ServerModpackManifest remoteManifest;
-    private final List<Task<?>> dependencies = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
 
     public ServerModpackCompletionTask(DefaultDependencyManager dependencyManager, String version) {
         this(dependencyManager, version, null);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackLocalInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackLocalInstallTask.java
@@ -32,7 +32,7 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ServerModpackLocalInstallTask extends Task<Void> {
@@ -42,8 +42,8 @@ public class ServerModpackLocalInstallTask extends Task<Void> {
     private final ServerModpackManifest manifest;
     private final String name;
     private final DefaultGameRepository repository;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>();
+    private final List<Task<?>> dependents = new ArrayList<>(4);
 
     public ServerModpackLocalInstallTask(DefaultDependencyManager dependencyManager, File zipFile, Modpack modpack, ServerModpackManifest manifest, String name) {
         this.zipFile = zipFile;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackRemoteInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackRemoteInstallTask.java
@@ -29,8 +29,8 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 public class ServerModpackRemoteInstallTask extends Task<Void> {
@@ -38,8 +38,8 @@ public class ServerModpackRemoteInstallTask extends Task<Void> {
     private final String name;
     private final DefaultDependencyManager dependency;
     private final DefaultGameRepository repository;
-    private final List<Task<?>> dependencies = new LinkedList<>();
-    private final List<Task<?>> dependents = new LinkedList<>();
+    private final List<Task<?>> dependencies = new ArrayList<>(1);
+    private final List<Task<?>> dependents = new ArrayList<>(1);
     private final ServerModpackManifest manifest;
 
     public ServerModpackRemoteInstallTask(DefaultDependencyManager dependencyManager, ServerModpackManifest manifest, String name) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/TaskExecutor.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/TaskExecutor.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class TaskExecutor {
     protected final Task<?> firstTask;
-    protected final List<TaskListener> taskListeners = new LinkedList<>();
+    protected final List<TaskListener> taskListeners = new ArrayList<>();
     protected final AtomicInteger totTask = new AtomicInteger(0);
     protected final AtomicBoolean cancelled = new AtomicBoolean(false);
     protected Exception exception;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/StringUtils.java
@@ -199,13 +199,13 @@ public final class StringUtils {
 
     public static List<String> tokenize(String str) {
         if (str == null)
-            return new LinkedList<>();
+            return new ArrayList<>();
         else
             return tokenize(str, " \t\n\r\f");
     }
 
     public static List<String> tokenize(String str, String delim) {
-        LinkedList<String> result = new LinkedList<>();
+        ArrayList<String> result = new ArrayList<>();
         StringTokenizer tokenizer = new StringTokenizer(str, delim);
         while (tokenizer.hasMoreTokens()) {
             delim = tokenizer.nextToken();

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/FileUtils.java
@@ -28,7 +28,7 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -393,7 +393,7 @@ public final class FileUtils {
     }
 
     public static List<File> listFilesByExtension(File file, String extension) {
-        List<File> result = new LinkedList<>();
+        List<File> result = new ArrayList<>();
         File[] files = file.listFiles();
         if (files != null)
             for (File it : files)

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/CommandBuilder.java
@@ -35,7 +35,7 @@ public final class CommandBuilder {
     private static final Pattern UNSTABLE_BOOLEAN_OPTION_PATTERN = Pattern.compile("-XX:(?<value>[+\\-])(?<key>[a-zA-Z0-9]+)");
 
     private final OperatingSystem os;
-    private final List<Item> raw = new LinkedList<>();
+    private final List<Item> raw = new ArrayList<>();
 
     public CommandBuilder() {
         this(OperatingSystem.CURRENT_OS);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
@@ -34,7 +34,7 @@ public class ManagedProcess {
     private final String classpath;
     private final Map<String, Object> properties = new HashMap<>();
     private final Queue<String> lines = new ConcurrentLinkedQueue<>();
-    private final List<Thread> relatedThreads = new LinkedList<>();
+    private final List<Thread> relatedThreads = new ArrayList<>();
 
     /**
      * Constructor.


### PR DESCRIPTION
在 Java 中，`LinkedList` 对 CPU 缓存不友好，因此性能很差，而且**内存开销很大**，所以除了经常要删除首元素等特殊状况，
否则 `LinkedList` 基本是不应该被使用的。

在各类 Task 中，被初始化为 `LinkedList` 的 `dependencies` 和 `dependents` 字段很多，而它们往往只会被调用一次 `add`，
因此我猜可能是 @huanghongxun 对 `LinkedList` 与 `ArrayList` 的内存布局有一些误解造成的。

下面所说的主要基于 HMCL 的常规工况，适用于从 Java 8 一直到目前最新版本 Java 的 HotSpot，堆内存小于 32G 的情况。
这些情况下压缩类指针和压缩对象指针默认是开启的，而且几乎没有人会去关闭它们，也就是说对象头占据 8+4 字节，而每个指针都是 4 字节。

在这种最常见的情况下，`LinkedList` 和其内部用于存储数据的 `LinkedList.Node` 内存布局如下：

```
java.util.LinkedList object internals:
OFF  SZ                        TYPE DESCRIPTION               VALUE
  0   8                             (object header: mark)     0x0000000000000001 (non-biasable; age: 0)
  8   4                             (object header: class)    0x001ee1a8
 12   4                         int AbstractList.modCount     0
 16   4                         int LinkedList.size           0
 20   4   java.util.LinkedList.Node LinkedList.first          null
 24   4   java.util.LinkedList.Node LinkedList.last           null
 28   4                             (object alignment gap)
Instance size: 32 bytes

java.util.LinkedList$Node object internals:
OFF  SZ                        TYPE DESCRIPTION               VALUE
  0   8                             (object header: mark)     N/A
  8   4                             (object header: class)    N/A
 12   4            java.lang.Object Node.item                 N/A
 16   4   java.util.LinkedList.Node Node.next                 N/A
 20   4   java.util.LinkedList.Node Node.prev                 N/A
Instance size: 24 bytes
```

也就是说，一个空的 `LinkedList` 占用 32 字节内存，而每存储一个元素都额外需要 24 字节的内存。

而 `ArrayList` 的布局如下：

```
java.util.ArrayList object internals:
OFF  SZ                 TYPE DESCRIPTION               VALUE
  0   8                      (object header: mark)     0x0000000000000001 (non-biasable; age: 0)
  8   4                      (object header: class)    0x0000d7a0
 12   4                  int AbstractList.modCount     0
 16   4                  int ArrayList.size            0
 20   4   java.lang.Object[] ArrayList.elementData     []
Instance size: 24 bytes
```

使用 `new ArrayList<>()` 和 `new ArrayList<>(0)` 创建的 `ArrayList` 引用了全局静态缓存的空数组，不需要额外空间，
所以空的 `ArrayList` 仅需要 24 字节。

`ArrayList` 构造器接受了一个初始大小。对于以上用例，我们可以使用 `new ArrayList<>(1)` 构造列表。
大小为 1 或者 2 的数组内存布局如下：

```
[Ljava.lang.Object; object internals:
OFF  SZ               TYPE DESCRIPTION               VALUE
  0   8                    (object header: mark)     0x0000000000000001 (non-biasable; age: 0)
  8   4                    (object header: class)    0x00001528
 12   4                    (array length)            2
 12   4                    (alignment/padding gap)
 16   8   java.lang.Object Object;.<elements>        N/A
Instance size: 24 bytes
```

数组大小为奇数时，由于内存对齐，需要在最后填充 4 字节，所以大小为 1 和 2 的数组实际内存占用是一样的。之后数组大小每再增大 2，占用内存多 8 字节。
也就是说，如果我们在上述的那些 Task 中用 `new ArrayList<>(1)` 代替 `new LinkedList<>()`，
那么每个列表的大小将减小 `(32+24) - (24+24) = 8` 字节。如果需要存储两个元素，则减小 32 字节。

随着列表元素的增多，在不考虑 `ArrayList` 内部数组后部空余空间的情况下，`LinkedList` 的内存占用将趋近于 `ArrayList` 的八倍；哪怕考虑到数组空余部分，根据 `ArrayList` 1.5 倍增长的策略，即使刚刚扩容完这种极限情况，`LinkedList` 内存占用也高于 `ArrayList` 的五倍。
而且由于不是连续存储，`LinkedList` 对于 CPU 缓存很不友好，即使部分操作复杂度较低，但系数很高，性能反而可能更差。

考虑到内存占用以及性能问题，请尽可能的避免使用 `LinkedList`。

另外要注意的是，`new ArrayList<>()` 和 `new ArrayList<>(0)` 的扩容方式是不同的，显式传入 0 的时候，`ArrayList` 不会让数组容量一步增长到默认容量（10），而是遵循 1.5 倍原则，`1 -> 2 -> 3 -> 4 -> 6 -> ...` 这样一步步扩容。