### PR TITLE
修复多人联机界面过大的问题

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -663,7 +663,7 @@ multiplayer.exit.timeout.dynamic_token=无法连接多人联机服务，你可�
 multiplayer.hint=多人联机功能处于实验阶段，如果有问题请反馈。
 multiplayer.nat=网络检测
 multiplayer.nat.failed=检测失败，但你仍然可以继续使用联机功能。
-multiplayer.nat.hint=执行网络检测可以让你更清楚你的网络状况是否符合联机功能的需求。检测结果为差的网络可能导致联机失败。
+multiplayer.nat.hint=执行网络检测可以让你更清楚你的网络状况是否符合联机功能的需求\n检测结果为差的网络可能导致联机失败
 multiplayer.nat.latency=延迟
 multiplayer.nat.not_yet_tested=尚未检测
 multiplayer.nat.packet_loss_ratio=丢包率
@@ -677,9 +677,9 @@ multiplayer.nat.type.restricted_cone=中（受限圆锥型）
 multiplayer.nat.type.symmetric=差（对称型）
 multiplayer.nat.type.symmetric_udp_firewall=差（对称型+防火墙）
 multiplayer.nat.type.unknown=未知
-multiplayer.powered_by=多人联机服务由 这里 (<a href="https://noin.cn">noin.cn</a>) 提供。<a href="https://noin.cn/agreement">用户协议与免责声明</a>
+multiplayer.powered_by=多人联机服务由 (<a href="https://noin.cn">noin.cn</a>) 提供 <a href="https://noin.cn/agreement">用户协议与免责声明</a>
 multiplayer.relay=桥接服务
-multiplayer.relay.hint=Cato 面向较差网络情况提供的网络质量增强优化解决方案。若无法联机请到 这里 的个人中心兑换凭证后启用。
+multiplayer.relay.hint=Cato 面向较差网络情况提供的联机质量优化解决方案  无法联机时可在 这里 兑换凭证后启用
 multiplayer.report=违法违规举报
 multiplayer.session=房间
 multiplayer.session.name.format=%1$s 的房间


### PR DESCRIPTION
通过缩短I18N_zh_CN.properties中的字段解决多人联机界面过大的问题
效果图：
![图片](https://user-images.githubusercontent.com/64117916/147881786-87c5e77a-e441-458e-b3dd-8f9a2081a807.png)
未经过修改：
![图片](https://user-images.githubusercontent.com/64117916/147881880-cd61cd26-e822-4d3d-b774-92c87574df90.png)
