### PR TITLE
调整默认内存分配策略

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -454,6 +454,20 @@ public class HMCLGameRepository extends DefaultGameRepository {
     }
 
     public static long getAllocatedMemory(long minimum, long available, boolean auto) {
-        return auto ? Math.max(minimum, (long) (available * 0.8)) : minimum;
+        if (auto) {
+            available -= 256 * 1024 * 1024; // Reserve 256MB memory for off-heap memory and HMCL itself
+            if (available <= 0) {
+                return minimum;
+            }
+
+            final long threshold = 8L * 1024 * 1024 * 1024;
+            final long suggested = Math.min(available <= threshold
+                            ? (long) (available * 0.8)
+                            : (long) (threshold * 0.8 + (available - threshold) * 0.2),
+                    32736L * 1024 * 1024); // Limit the maximum suggested memory to ensure that compressed oops are available
+            return Math.max(minimum, suggested);
+        } else {
+            return minimum;
+        }
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -180,7 +180,7 @@ public enum OperatingSystem {
                 .map(bytes -> (int) (bytes / 1024 / 1024))
                 .orElse(1024);
 
-        SUGGESTED_MEMORY = (int) (Math.round(1.0 * TOTAL_MEMORY / 4.0 / 128.0) * 128);
+        SUGGESTED_MEMORY = TOTAL_MEMORY >= 32768 ? 8192 : (int) (Math.round(1.0 * TOTAL_MEMORY / 4.0 / 128.0) * 128);
 
         // setup the invalid names
         if (CURRENT_OS == WINDOWS) {


### PR DESCRIPTION
* 推荐内存最大不应该超过 8GB
* 对于自动内存分配
  * 额外预留 256 MB 空间给堆外内存与 HMCL 自身；
  * 空闲内存低于 8GB 时分配 80%，而超过 8G 的部分分配 20%；
  * 自动内存分配不应该超过 32736MB，否则会导致压缩指针被禁用，更容易造成 OOM。