### PR TITLE
预防 HMCL 退出时崩溃

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -258,8 +258,11 @@ public enum OperatingSystem {
 
     public static void forceGC() {
         System.gc();
-        System.runFinalization();
-        System.gc();
+        try {
+            System.runFinalization();
+            System.gc();
+        } catch (NoSuchMethodError ignored) {
+        }
     }
 
     public static Path getWorkingDirectory(String folder) {


### PR DESCRIPTION
根据 [JEP 421](https://openjdk.java.net/jeps/421)，`finalize` 方法即将被最终弃用，`System.runFinalization` 也将会被删除。

在 Java 18 中，`System.runFinalization` 已经带有 `@Deprecated(since="18", forRemoval=true)` 注解：

https://github.com/openjdk/jdk/blob/ec7cb6d5d305003429b51384ed72973767c70124/src/java.base/share/classes/java/lang/System.java#L1935

因此，应该做出一些预防措施避免 HMCL 在退出时因调用不存在方法发生崩溃。

