### PR TITLE
修复导出崩溃信息失败

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.game;
 
-import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.Zipper;
@@ -77,6 +76,6 @@ public final class LogExporter {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        }, Schedulers.io());
+        });
     }
 }


### PR DESCRIPTION
参见 #1297，导出崩溃信息时 `Schedulers.io()` 已经关闭，不应该使用它调度导出任务。