### PR TITLE
将HMCL多人联机界面显示cato版本号的后缀删除

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerManager.java
@@ -60,7 +60,7 @@ import static org.jackhuang.hmcl.util.Logging.LOG;
  * Cato Management.
  */
 public final class MultiplayerManager {
-    static final String CATO_VERSION = "1.2.1-1642413526";
+    static final String CATO_VERSION = "1.2.1";
     private static final String CATO_DOWNLOAD_URL = "https://gitcode.net/to/cato/-/raw/master/client/";
     private static final String CATO_HASH_URL = CATO_DOWNLOAD_URL + "cato-all-files.sha1";
     private static final String CATO_PATH = getCatoPath();


### PR DESCRIPTION
将HMCL多人联机界面显示cato版本号的后缀删除，原因是https://gitcode.net/to/cato/-/raw/master/client/ 他会自动更新，只要仓库更新，HMCL的cato就会更新，但是HMCL多人联机界面显示的cato版本号不会更新，所以将后缀去掉。
如果有什么更好的方法
那就不用合并，直接close吧