### PR TITLE
自动补全缺失的 OptiFine 文件

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -138,18 +138,12 @@ public final class LauncherHelper {
         TaskExecutor executor = checkGameState(profile, setting, version)
                 .thenComposeAsync(javaVersion -> {
                     javaVersionRef.set(Objects.requireNonNull(javaVersion));
-                    return dependencyManager.checkPatchCompletionAsync(repository.getVersion(selectedVersion), integrityCheck);
-                })
-                .thenComposeAsync(Task.allOf(
-                        Task.composeAsync(() -> {
-                            if (setting.isNotCheckGame())
-                                return null;
-                            else
-                                return dependencyManager.checkGameCompletionAsync(version, integrityCheck);
-                        }), Task.composeAsync(() -> {
-                            if (setting.isNotCheckGame()) {
-                                return null;
-                            } else {
+                    if (setting.isNotCheckGame())
+                        return null;
+
+                    return Task.allOf(
+                            dependencyManager.checkGameCompletionAsync(version, integrityCheck),
+                            Task.composeAsync(() -> {
                                 try {
                                     ModpackConfiguration<?> configuration = ModpackHelper.readModpackConfiguration(repository.getModpackConfiguration(selectedVersion));
                                     if (CurseInstallTask.MODPACK_TYPE.equals(configuration.getType()))
@@ -163,8 +157,9 @@ public final class LauncherHelper {
                                 } catch (IOException e) {
                                     return null;
                                 }
-                            }
-                        }))).withStage("launch.state.dependencies")
+                            })
+                    );
+                }).withStage("launch.state.dependencies")
                 .thenComposeAsync(() -> {
                     return gameVersion.map(s -> new GameVerificationFixTask(dependencyManager, s, version)).orElse(null);
                 })

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultDependencyManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultDependencyManager.java
@@ -22,6 +22,7 @@ import org.jackhuang.hmcl.download.game.GameAssetDownloadTask;
 import org.jackhuang.hmcl.download.game.GameDownloadTask;
 import org.jackhuang.hmcl.download.game.GameLibrariesTask;
 import org.jackhuang.hmcl.download.optifine.OptiFineInstallTask;
+import org.jackhuang.hmcl.game.Artifact;
 import org.jackhuang.hmcl.game.DefaultGameRepository;
 import org.jackhuang.hmcl.game.Library;
 import org.jackhuang.hmcl.game.Version;
@@ -32,10 +33,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.OPTIFINE;
 
 /**
  * Note: This class has no state.
@@ -75,8 +73,7 @@ public class DefaultDependencyManager extends AbstractDependencyManager {
     }
 
     @Override
-    public Task<?> checkGameCompletionAsync(Version original, boolean integrityCheck) {
-        Version version = original.resolve(repository);
+    public Task<?> checkGameCompletionAsync(Version version, boolean integrityCheck) {
         return Task.allOf(
                 Task.composeAsync(() -> {
                     File versionJar = repository.getVersionJar(version);
@@ -84,7 +81,7 @@ public class DefaultDependencyManager extends AbstractDependencyManager {
                         return new GameDownloadTask(this, null, version);
                     else
                         return null;
-                }),
+                }).thenComposeAsync(checkPatchCompletionAsync(version, integrityCheck)),
                 new GameAssetDownloadTask(this, version, GameAssetDownloadTask.DOWNLOAD_INDEX_IF_NECESSARY, integrityCheck),
                 new GameLibrariesTask(this, version, integrityCheck)
         );
@@ -98,31 +95,34 @@ public class DefaultDependencyManager extends AbstractDependencyManager {
     @Override
     public Task<?> checkPatchCompletionAsync(Version version, boolean integrityCheck) {
         return Task.composeAsync(() -> {
-            List<Task<?>> tasks = new ArrayList<>();
+            List<Task<?>> tasks = new ArrayList<>(0);
 
-            Optional<String> gameVersion = repository.getGameVersion(version);
-            if (!gameVersion.isPresent()) return null;
+            String gameVersion = repository.getGameVersion(version).orElse(null);
+            if (gameVersion == null) return null;
 
-            LibraryAnalyzer analyzer = LibraryAnalyzer.analyze(version.resolvePreservingPatches(getGameRepository()));
-            for (LibraryAnalyzer.LibraryType type : LibraryAnalyzer.LibraryType.values()) {
-                Optional<Library> library = analyzer.getLibrary(type);
-                if (library.isPresent() && GameLibrariesTask.shouldDownloadLibrary(repository, version, library.get(), integrityCheck)) {
-                    tasks.add(downloadMissingLibraryAsync(gameVersion.get(), version, type, library.get()));
+            Version original = repository.getVersion(version.getId());
+            Version resolved = original.resolvePreservingPatches(repository);
+
+            // OptiFine
+            String optifineVersion = resolved.getPatches().stream()
+                    .filter(patch -> "optifine".equals(patch.getId()))
+                    .findAny()
+                    .filter(optifine -> optifine.getLibraries().stream()
+                            .anyMatch(library -> GameLibrariesTask.shouldDownloadLibrary(repository, version, library, integrityCheck)))
+                    .map(Version::getVersion)
+                    .orElse(null);
+
+            if (optifineVersion != null) {
+                Library installer = new Library(new Artifact("optifine", "OptiFine", gameVersion + "_" + optifineVersion, "installer"));
+                if (GameLibrariesTask.shouldDownloadLibrary(repository, original, installer, integrityCheck)) {
+                    tasks.add(installLibraryAsync(gameVersion, original, "optifine", optifineVersion));
+                } else {
+                    tasks.add(OptiFineInstallTask.install(this, original, repository.getLibraryFile(version, installer).toPath()));
                 }
             }
+
             return Task.allOf(tasks);
         });
-    }
-
-    private Task<?> downloadMissingLibraryAsync(String gameVersion, Version version, LibraryAnalyzer.LibraryType libraryType, Library library) {
-        switch (libraryType) {
-            case OPTIFINE:
-                if (library.hasDownloadURL())
-                    break;
-
-                return installLibraryAsync(gameVersion, version, libraryType.getPatchId(), library.getVersion());
-        }
-        return Task.completed(null);
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DependencyManager.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DependencyManager.java
@@ -49,8 +49,8 @@ public interface DependencyManager {
     Task<?> checkGameCompletionAsync(Version version, boolean integrityCheck);
 
     /**
-     * Check if the game is complete.
-     * Check libraries, assets files and so on.
+     * Check if libraries of this version in complete.
+     * If not, download missing libraries if possible.
      *
      * @return the task to check game completion.
      */

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameLibrariesTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameLibrariesTask.java
@@ -109,7 +109,8 @@ public final class GameLibrariesTask extends Task<Void> {
         libraries.stream().filter(Library::appliesToCurrentEnvironment).forEach(library -> {
             File file = dependencyManager.getGameRepository().getLibraryFile(version, library);
             if (shouldDownloadLibrary(dependencyManager.getGameRepository(), version, library, integrityCheck)) {
-                dependencies.add(new LibraryDownloadTask(dependencyManager, file, library));
+                if (library.hasDownloadURL() || !"optifine".equals(library.getGroupId()))
+                    dependencies.add(new LibraryDownloadTask(dependencyManager, file, library));
             } else {
                 dependencyManager.getCacheRepository().tryCacheLibrary(library, file.toPath());
             }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FetchTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FetchTask.java
@@ -118,7 +118,7 @@ public abstract class FetchTask<T> extends Task<T> {
                                 continue;
                             }
                         } else if (responseCode / 100 == 4) {
-                            throw new FileNotFoundException();
+                            throw new FileNotFoundException(url.toString());
                         } else if (responseCode / 100 != 2) {
                             throw new ResponseCodeException(url, responseCode);
                         }


### PR DESCRIPTION
`checkPatchCompletionAsync` 似乎以前从未工作过，因为它设计上目前只能修复 OptiFine 缺失，但又因为 `LibraryAnalyzer` 找不到 OptiFine 的库文件，所以它也修不了 OptiFine 的缺失问题。

另外原先的修复顺序很迷，我不明白为什么原先 `checkPatchCompletionAsync` 要在 `checkGameCompletionAsync` 之前执行。`checkGameCompletionAsync` 才检查的 version jar 的完整性，而 `checkPatchCompletionAsync` 的补全是需要 version jar 完整才能进行，没有导致崩溃似乎完全因为 `checkPatchCompletionAsync` 根本就没生效过……

 