### PR TITLE
Replace 'Launcher.getCurrentJarFiles()' with 'JarUtils.thisJar()'

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -31,19 +31,14 @@ import org.jackhuang.hmcl.upgrade.UpdateHandler;
 import org.jackhuang.hmcl.util.CrashReporter;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.StringUtils;
-import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.awt.*;
-import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.management.ManagementFactory;
 import java.net.*;
 import java.nio.file.Paths;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
@@ -156,35 +151,6 @@ public final class Launcher extends Application {
             Controllers.shutdown();
             Lang.executeDelayed(OperatingSystem::forceGC, TimeUnit.SECONDS, 5, true);
         });
-    }
-
-    public static List<File> getCurrentJarFiles() {
-        List<File> result = new LinkedList<>();
-        if (Launcher.class.getClassLoader() instanceof URLClassLoader) {
-            URL[] urls = ((URLClassLoader) Launcher.class.getClassLoader()).getURLs();
-            for (URL u : urls)
-                try {
-                    File f = new File(u.toURI());
-                    if (f.isFile() && (f.getName().endsWith(".exe") || f.getName().endsWith(".jar")))
-                        result.add(f);
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-        } else {
-            try {
-                File jarFile = new File(URLDecoder.decode(Launcher.class.getProtectionDomain().getCodeSource().getLocation().getPath(), "UTF-8"));
-                String ext = FileUtils.getExtension(jarFile);
-                if ("jar".equals(ext) || "exe".equals(ext))
-                    result.add(jarFile);
-            } catch (UnsupportedEncodingException e) {
-                LOG.log(Level.WARNING, "Failed to decode jar path", e);
-                return null;
-            }
-        }
-        if (result.isEmpty())
-            return null;
-        else
-            return result;
     }
 
     public static final CrashReporter CRASH_REPORTER = new CrashReporter(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ExportWizardProvider.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.export;
 
 import javafx.scene.Node;
-import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.mod.ModAdviser;
 import org.jackhuang.hmcl.mod.ModpackExportInfo;
 import org.jackhuang.hmcl.mod.mcbbs.McbbsModpackExportTask;
@@ -33,14 +32,13 @@ import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardProvider;
 import org.jackhuang.hmcl.util.Lang;
+import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.io.Zipper;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.nio.file.Path;
+import java.util.*;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 
@@ -70,8 +68,8 @@ public final class ExportWizardProvider implements WizardProvider {
     }
 
     private Task<?> exportWithLauncher(String modpackType, ModpackExportInfo exportInfo, File modpackFile) {
-        List<File> launcherJar = Launcher.getCurrentJarFiles();
-        boolean packWithLauncher = exportInfo.isPackWithLauncher() && launcherJar != null;
+        Optional<Path> launcherJar = JarUtils.thisJar();
+        boolean packWithLauncher = exportInfo.isPackWithLauncher() && launcherJar.isPresent();
         return new Task<Object>() {
             File tempModpack;
             Task<?> exportTask;
@@ -139,8 +137,7 @@ public final class ExportWizardProvider implements WizardProvider {
                     if (background_jpg.isFile())
                         zip.putFile(background_jpg, "background.jpg");
 
-                    for (File jar : launcherJar)
-                        zip.putFile(jar, jar.getName());
+                    zip.putFile(launcherJar.get(), launcherJar.get().getFileName().toString());
                 }
             }
         };

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/export/ModpackInfoPage.java
@@ -29,7 +29,6 @@ import javafx.scene.control.*;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
-import org.jackhuang.hmcl.Launcher;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.authlibinjector.AuthlibInjectorServer;
 import org.jackhuang.hmcl.game.HMCLGameRepository;
@@ -43,6 +42,7 @@ import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.ui.wizard.WizardController;
 import org.jackhuang.hmcl.ui.wizard.WizardPage;
 import org.jackhuang.hmcl.util.StringUtils;
+import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.File;
@@ -96,8 +96,7 @@ public final class ModpackInfoPage extends Control implements WizardPage {
         launchArguments.set(versionSetting.getMinecraftArgs());
         javaArguments.set(versionSetting.getJavaArgs());
 
-        List<File> launcherJar = Launcher.getCurrentJarFiles();
-        canIncludeLauncher = launcherJar != null;
+        canIncludeLauncher = JarUtils.thisJar().isPresent();
 
         next.set(e -> onNext());
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/JarUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/JarUtils.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.util.io;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,29 +33,21 @@ public final class JarUtils {
     private JarUtils() {
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static final Optional<Path> THIS_JAR =
+            Optional.ofNullable(JarUtils.class.getProtectionDomain().getCodeSource())
+                    .map(CodeSource::getLocation)
+                    .map(url -> {
+                        try {
+                            return Paths.get(url.toURI());
+                        } catch (FileSystemNotFoundException | IllegalArgumentException | URISyntaxException e) {
+                            return null;
+                        }
+                    })
+                    .filter(Files::isRegularFile);
+
     public static Optional<Path> thisJar() {
-        CodeSource codeSource = JarUtils.class.getProtectionDomain().getCodeSource();
-        if (codeSource == null) {
-            return Optional.empty();
-        }
-
-        URL url = codeSource.getLocation();
-        if (url == null) {
-            return Optional.empty();
-        }
-
-        Path path;
-        try {
-            path = Paths.get(url.toURI());
-        } catch (FileSystemNotFoundException | IllegalArgumentException | URISyntaxException e) {
-            return Optional.empty();
-        }
-
-        if (!Files.isRegularFile(path)) {
-            return Optional.empty();
-        }
-
-        return Optional.of(path);
+        return THIS_JAR;
     }
 
     public static Optional<Manifest> getManifest(Path jar) {


### PR DESCRIPTION
#1034 的重制。

HMCL 目前几乎总是假设自己属于 shadowJar，否则可能出现许多奇怪问题，导致 `Launcher.getCurrentJarFiles()` 缺乏实际意义。