### PR TITLE
修复下载 Java 时产生的崩溃

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
@@ -116,6 +116,7 @@ public class JavaDownloadTask extends Task<Void> {
                 Files.createDirectories(dest);
             } else if (entry.getValue() instanceof RemoteFiles.RemoteLink) {
                 RemoteFiles.RemoteLink link = ((RemoteFiles.RemoteLink) entry.getValue());
+                Files.deleteIfExists(dest);
                 Files.createSymbolicLink(dest, Paths.get(link.getTarget()));
             }
         }


### PR DESCRIPTION
符号链接已存在时，`createSymbolicLink` 会抛出 `FileAlreadyExistsException`。