### PR TITLE
fix import curse forge modpack without modlist.html

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
@@ -227,7 +227,7 @@ public final class CompressingUtils {
     public static Optional<String> readTextZipEntryQuietly(File file, String name) {
         try {
             return Optional.of(readTextZipEntry(file, name));
-        } catch (IOException e) {
+        } catch (IOException | NullPointerException e) {
             return Optional.empty();
         }
     }
@@ -242,7 +242,7 @@ public final class CompressingUtils {
     public static Optional<String> readTextZipEntryQuietly(Path file, String name, Charset encoding) {
         try {
             return Optional.of(readTextZipEntry(file, name, encoding));
-        } catch (IOException e) {
+        } catch (IOException | NullPointerException e) {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
读取不存在的文件时 `readTextZipEntry` 会抛 NPE 而不是 IOE，导致 `readTextZipEntryQuietly` 直接抛异常了，而不是返回 `Optional.empty()`。