### PR TITLE
[WIP] 支持加密登陆信息

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -145,6 +145,9 @@ public final class Config implements Cloneable, Observable {
     @SerializedName("accounts")
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
 
+    @SerializedName("secretAccounts")
+    private ObservableList<Map<Object, Object>> secretAccountStorages = FXCollections.observableArrayList();
+
     @SerializedName("fontFamily")
     private StringProperty fontFamily = new SimpleStringProperty("Consolas");
 
@@ -481,6 +484,10 @@ public final class Config implements Cloneable, Observable {
 
     public ObservableList<Map<Object, Object>> getAccountStorages() {
         return accountStorages;
+    }
+
+    public ObservableList<Map<Object, Object>> getSecretAccountStorages() {
+        return secretAccountStorages;
     }
 
     public String getFontFamily() {


### PR DESCRIPTION
*暂未最终决定实现方案，目前 PR 中代码仅为实验探索，确定后 reset 回去重做。*

见 #1376 #1377。

目前登陆 TOKEN 明文存储在 `hmcl.json` 中，容易在不经意间造成泄露，今天就有一位用户因此账户被盗用。

为了用户账号安全性，或应该考虑加强对 TOKEN 的保护，目前我设想的加密方案如下：

考虑到兼容性，保持对未加密登录数据的读写支持，并且允许部分 `Account` 进行 RSA 加密，存储时对应的条目中附加上一个 RSA 公钥。对于新登陆的微软账号以及外置登陆，默认开启加密，同时允许用户对已存在的登陆信息进行加密。每次用户登录时，都可以选择加密或不加密。

HMCL 应在全局某个地方（譬如 `HMCL_DIRECTORY` 里， 或者用 Java 的 `Preferences`）存储一组 RSA 密钥对，并指定一个作为默认加密用秘钥（在 `GlobalConfig` 中存储一个公钥？）。在用户尝试使用加密过的 `Account` 时，如果没有已知私钥可以解密，则提示用户导入私钥进行解密，同时也提供导出私钥的功能，这样便于用户同时管理多个不同电脑创建的 HMCL 文件夹。


