### PR TITLE
[WIP] 支持全局存储登陆信息

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -259,7 +259,7 @@ public class HMCLGameRepository extends DefaultGameRepository {
     public VersionSetting getVersionSetting(String id) {
         VersionSetting vs = getLocalVersionSetting(id);
         if (vs == null || vs.isUsesGlobal()) {
-            profile.getGlobal().setGlobal(true); // always keep global.isGlobal = true
+            profile.getGlobal().setGlobal(true); // always keep global.isPortable = true
             profile.getGlobal().setUsesGlobal(true);
             return profile.getGlobal();
         } else

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/AccountReference.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/AccountReference.java
@@ -1,0 +1,77 @@
+package org.jackhuang.hmcl.setting;
+
+import org.jackhuang.hmcl.auth.Account;
+import org.jackhuang.hmcl.util.ToStringBuilder;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class AccountReference {
+    private final String type;
+    private final String username;
+    private final String character;
+    private final UUID uuid;
+
+    public AccountReference(String type, String username, String character, UUID uuid) {
+        this.type = type;
+        this.username = username;
+        this.character = character;
+        this.uuid = uuid;
+    }
+
+    public static AccountReference ofAccount(Account account) {
+        if (account == null) {
+            return null;
+        }
+        String type = Accounts.getLoginType(Accounts.getAccountFactory(account));
+        return new AccountReference(type, account.getUsername(), account.getCharacter(), account.getUUID());
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getCharacter() {
+        return character;
+    }
+
+    public UUID getUUID() {
+        return uuid;
+    }
+
+    public boolean isReferenceTo(Account account) {
+        return Objects.equals(type, Accounts.getLoginType(Accounts.getAccountFactory(account)))
+                && Objects.equals(username, account.getUsername())
+                && Objects.equals(character, account.getCharacter())
+                && Objects.equals(uuid, account.getUUID());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AccountReference)) return false;
+        AccountReference that = (AccountReference) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(username, that.username)
+                && Objects.equals(character, that.character)
+                && Objects.equals(uuid, that.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, username, character, uuid);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("username", username)
+                .append("character", character)
+                .append("uuid", uuid)
+                .toString();
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -51,7 +51,7 @@ public final class Config implements Cloneable, Observable {
 
     public static final int CURRENT_UI_VERSION = 0;
 
-    private static final Gson CONFIG_GSON = new GsonBuilder()
+    static final Gson CONFIG_GSON = new GsonBuilder()
             .registerTypeAdapter(File.class, FileTypeAdapter.INSTANCE)
             .registerTypeAdapter(ObservableList.class, new ObservableListCreator())
             .registerTypeAdapter(ObservableSet.class, new ObservableSetCreator())

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -142,6 +142,9 @@ public final class Config implements Cloneable, Observable {
     @SerializedName("configurations")
     private ObservableMap<String, Profile> configurations = FXCollections.observableMap(new TreeMap<>());
 
+    @SerializedName("selectedAccount")
+    private ObjectProperty<AccountReference> selectedAccountReference = new SimpleObjectProperty<>();
+
     @SerializedName("accounts")
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
 
@@ -477,6 +480,18 @@ public final class Config implements Cloneable, Observable {
 
     public ObservableMap<String, Profile> getConfigurations() {
         return configurations;
+    }
+
+    public AccountReference getSelectedAccountReference() {
+        return selectedAccountReference.get();
+    }
+
+    public void setSelectedAccountReference(AccountReference selectedAccountReference) {
+        this.selectedAccountReference.set(selectedAccountReference);
+    }
+
+    public ObjectProperty<AccountReference> selectedAccountReferenceProperty() {
+        return selectedAccountReference;
     }
 
     public ObservableList<Map<Object, Object>> getAccountStorages() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
@@ -22,41 +22,19 @@ import com.google.gson.annotations.JsonAdapter;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.*;
-import javafx.collections.ObservableList;
-import javafx.collections.ObservableMap;
-import javafx.collections.ObservableSet;
-import org.hildan.fxgson.creators.ObservableListCreator;
-import org.hildan.fxgson.creators.ObservableMapCreator;
-import org.hildan.fxgson.creators.ObservableSetCreator;
-import org.hildan.fxgson.factories.JavaFxPropertyTypeAdapterFactory;
-import org.jackhuang.hmcl.util.gson.EnumOrdinalDeserializer;
-import org.jackhuang.hmcl.util.gson.FileTypeAdapter;
 import org.jackhuang.hmcl.util.javafx.ObservableHelper;
 import org.jackhuang.hmcl.util.javafx.PropertyUtils;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
 import java.lang.reflect.Type;
-import java.net.Proxy;
 import java.util.*;
 
 @JsonAdapter(GlobalConfig.Serializer.class)
 public class GlobalConfig implements Cloneable, Observable {
 
-    private static final Gson CONFIG_GSON = new GsonBuilder()
-            .registerTypeAdapter(File.class, FileTypeAdapter.INSTANCE)
-            .registerTypeAdapter(ObservableList.class, new ObservableListCreator())
-            .registerTypeAdapter(ObservableSet.class, new ObservableSetCreator())
-            .registerTypeAdapter(ObservableMap.class, new ObservableMapCreator())
-            .registerTypeAdapterFactory(new JavaFxPropertyTypeAdapterFactory(true, true))
-            .registerTypeAdapter(EnumBackgroundImage.class, new EnumOrdinalDeserializer<>(EnumBackgroundImage.class)) // backward compatibility for backgroundType
-            .registerTypeAdapter(Proxy.Type.class, new EnumOrdinalDeserializer<>(Proxy.Type.class)) // backward compatibility for hasProxy
-            .setPrettyPrinting()
-            .create();
-
     @Nullable
     public static GlobalConfig fromJson(String json) throws JsonParseException {
-        GlobalConfig loaded = CONFIG_GSON.fromJson(json, GlobalConfig.class);
+        GlobalConfig loaded = Config.CONFIG_GSON.fromJson(json, GlobalConfig.class);
         if (loaded == null) {
             return null;
         }
@@ -93,7 +71,7 @@ public class GlobalConfig implements Cloneable, Observable {
     }
 
     public String toJson() {
-        return CONFIG_GSON.toJson(this);
+        return Config.CONFIG_GSON.toJson(this);
     }
 
     @Override

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -76,13 +76,15 @@ public class AccountListItem extends RadioButton {
         setUserData(account);
 
         String loginTypeName = Accounts.getLocalizedLoginTypeName(Accounts.getAccountFactory(account));
+
+        StringBinding portable = Bindings.when(account.isPortableProperty()).then(", " + i18n("portable")).otherwise("");
         if (account instanceof AuthlibInjectorAccount) {
             AuthlibInjectorServer server = ((AuthlibInjectorAccount) account).getServer();
             subtitle.bind(Bindings.concat(
                     loginTypeName, ", ", i18n("account.injector.server"), ": ",
-                    Bindings.createStringBinding(server::getName, server)));
+                    Bindings.createStringBinding(server::getName, server), portable));
         } else {
-            subtitle.set(loginTypeName);
+            subtitle.bind(Bindings.concat(loginTypeName, portable));
         }
 
         StringBinding characterName = Bindings.createStringBinding(account::getCharacter, account);

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -765,6 +765,7 @@ world.reveal=Reveal in Explorer
 world.show_all=Show all
 world.time=EEE, MMM d, yyyy HH:mm:ss
 
+portable=Portable
 profile=Game Directories
 profile.already_exists=This name already exists, please use a different name.
 profile.default=Current directory

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -765,6 +765,7 @@ world.reveal=開啟資料夾
 world.show_all=全部顯示
 world.time=yyyy年MM月dd日 HH:mm:ss
 
+portable=便携
 profile=遊戲目錄
 profile.already_exists=該名稱已存在
 profile.default=目前目錄

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -765,6 +765,7 @@ world.reveal=打开文件夹
 world.show_all=显示全部
 world.time=yyyy 年 MM 月 dd 日 HH:mm:ss
 
+portable=便携
 profile=游戏目录
 profile.already_exists=该名称已存在
 profile.default=当前目录

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
@@ -23,6 +23,8 @@ import javafx.beans.Observable;
 
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import org.jackhuang.hmcl.auth.yggdrasil.Texture;
 import org.jackhuang.hmcl.auth.yggdrasil.TextureType;
 import org.jackhuang.hmcl.util.ToStringBuilder;
@@ -38,16 +40,6 @@ import java.util.UUID;
  */
 public abstract class Account implements Observable {
 
-    private boolean isGlobal;
-
-    public boolean isGlobal() {
-        return isGlobal;
-    }
-
-    public void setIsGlobal(boolean isGlobal) {
-        this.isGlobal = isGlobal;
-    }
-
     /**
      * @return the name of the account who owns the character
      */
@@ -62,6 +54,20 @@ public abstract class Account implements Observable {
      * @return the character UUID
      */
     public abstract UUID getUUID();
+
+    private final BooleanProperty isPortableProperty = new SimpleBooleanProperty(true);
+
+    public boolean isPortable() {
+        return isPortableProperty.get();
+    }
+
+    public void setPortable(boolean isPortable) {
+        isPortableProperty.set(isPortable);
+    }
+
+    public BooleanProperty isPortableProperty() {
+        return isPortableProperty;
+    }
 
     /**
      * Login with stored credentials.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/Account.java
@@ -38,6 +38,16 @@ import java.util.UUID;
  */
 public abstract class Account implements Observable {
 
+    private boolean isGlobal;
+
+    public boolean isGlobal() {
+        return isGlobal;
+    }
+
+    public void setIsGlobal(boolean isGlobal) {
+        this.isGlobal = isGlobal;
+    }
+
     /**
      * @return the name of the account who owns the character
      */


### PR DESCRIPTION
见 https://github.com/huanghongxun/HMCL/pull/1378#issuecomment-1055012717 ：

> 根据用户反馈，看起来用户也有在多个文件夹中共享相同登录的需求，或许选择支持全局存储登录信息更好一些？相对来说，这样做理解成本更低，而且兼容性更好。
> （主要是加密做起来有点烦，所以最近一直在摸鱼）
> 
> 目前想法是：
> 
> * 同时支持账号信息存储在 `HMCL_DIRECTORY` 或者 `hmcl.json` 里；
> * 新的登录默认存储在 `HMCL_DIRECTORY` 中；
> * 用户登录时可以主动选择将登录信息存放在 `hmcl.json` 里。
> 
> 继续支持存放在  `hmcl.json` 里的目的是：
> 1. 兼容性；
> 2. 整合包作者可以预置一些离线登录；
> 3. 满足用户多设备共享需求（譬如将 MC 放在移动硬盘/U盘里）。
