### PR TITLE
fix #1385: crash when show DatapackListPage

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DatapackListPageSkin.java
@@ -82,7 +82,6 @@ class DatapackListPageSkin extends SkinBase<DatapackListPage> {
 
                 {
                     Region clippedContainer = (Region)listView.lookup(".clipped-container");
-                    setPrefWidth(0);
                     HBox container = new HBox(8);
                     container.setPadding(new Insets(0, 0, 0, 6));
                     container.setAlignment(Pos.CENTER_LEFT);


### PR DESCRIPTION
应该是 b2594122a89cb5a6a952c016d73bf85e511d5f90 中引入的问题，更改了调用的构造器导致在 `setPrefWidth(0)` 就已经绑定了值。