### PR TITLE
Update java-download.ps1

### DIFF
--- a/HMCLauncher/HMCL/java-download.ps1
+++ b/HMCLauncher/HMCL/java-download.ps1
@@ -79,10 +79,10 @@ if ($result -ne [System.Windows.Forms.DialogResult]::Yes) {
 if ($useMirrorCheckBox.Checked) {
   switch ($Arch) {
       'x86-64' {
-          $script:url = 'https://download.bell-sw.com/java/17.0.2+9/bellsoft-jre17.0.2+9-windows-amd64-full.zip'
+          $script:url = 'https://gitcode.net/chearlai/hmcl-java/-/raw/master/java/win_x64.zip'
       }
       'x86' {
-          $script:url = 'https://download.bell-sw.com/java/17.0.2+9/bellsoft-jre17.0.2+9-windows-i586-full.zip'
+          $script:url = 'https://gitcode.net/chearlai/hmcl-java/-/raw/master/java/win_i686.zip'
       }
       default { exit 1 }
   }


### PR DESCRIPTION
将Java中国加速下载渠道弄到了 https://gitcode.net/chearlai/hmcl-java/ ，速度还是很快的

或许可以用黄鱼自己的账号来弄，便于自己管理？