### PR TITLE
禁止使用 Mojang 登陆

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/CreateAccountPane.java
@@ -300,6 +300,24 @@ public class CreateAccountPane extends JFXDialogLayout implements DialogAware {
 
             detailsPane = vbox;
             btnAccept.setDisable(false);
+        } else if (factory == Accounts.FACTORY_MOJANG) {
+            VBox vbox = new VBox(8);
+            HintPane hintPane = new HintPane(MessageDialogPane.MessageType.WARNING);
+            hintPane.setText(i18n("account.methods.yggdrasil.migration.hint"));
+
+            HBox linkPane = new HBox(8);
+
+            JFXHyperlink migrationLink = new JFXHyperlink(i18n("account.methods.yggdrasil.migration"));
+            migrationLink.setOnAction(e -> FXUtils.openLink(YggdrasilService.PROFILE_URL));
+
+            JFXHyperlink migrationHowLink = new JFXHyperlink(i18n("account.methods.yggdrasil.migration.how"));
+            migrationHowLink.setOnAction(e -> FXUtils.openLink(YggdrasilService.MIGRATION_FAQ_URL));
+
+            linkPane.getChildren().setAll(migrationLink, migrationHowLink);
+
+            vbox.getChildren().setAll(hintPane, linkPane);
+            detailsPane = vbox;
+            btnAccept.setDisable(true);
         } else {
             detailsPane = new AccountDetailsInputPane(factory, btnAccept::fire);
             btnAccept.disableProperty().bind(((AccountDetailsInputPane) detailsPane).validProperty().not());

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -108,6 +108,7 @@ account.methods.offline.uuid.malformed=Malformed
 account.methods.yggdrasil=Mojang
 account.methods.yggdrasil.migration=Migrate to Microsoft Account
 account.methods.yggdrasil.migration.how=How to migrate to Microsoft Account?
+account.methods.yggdrasil.migration.hint=As of March 10, 2022, Mojang accounts are no longer supported, and you must migrate to a Microsoft account to log into Minecraft.\nThe link below will guide you to migrate your Mojang account to a Microsoft account.
 account.methods.yggdrasil.purchase=Purchase Minecraft
 account.missing=No Account
 account.missing.add=Click here to add

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -108,6 +108,7 @@ account.methods.offline.uuid.malformed=格式錯誤
 account.methods.yggdrasil=Mojang 登入
 account.methods.yggdrasil.migration=遷移至微軟帳戶
 account.methods.yggdrasil.migration.how=如何遷移至微軟帳戶？
+account.methods.yggdrasil.migration.hint=自 2022 年 3 月 10 日起，Mojang 帳戶不再受支持，您必須遷移至微軟帳戶才能登入 Minecraft。\n下方連結將指引您將 Mojang 帳戶遷移至微軟帳戶。
 account.methods.yggdrasil.purchase=購買 Minecraft
 account.missing=沒有遊戲帳戶
 account.missing.add=按一下此處加入帳戶

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -108,6 +108,7 @@ account.methods.offline.uuid.malformed=格式错误
 account.methods.yggdrasil=Mojang 帐户
 account.methods.yggdrasil.migration=迁移至微软账户
 account.methods.yggdrasil.migration.how=如何迁移至微软帐户？
+account.methods.yggdrasil.migration.hint=自 2022 年 3 月 10 日起，Mojang 账户不再受支持，您必须迁移至微软账户才能登陆 Minecraft。\n下方链接将指引您将Mojang账户迁移至微软账户。
 account.methods.yggdrasil.purchase=购买 Minecraft
 account.missing=没有游戏帐户
 account.missing.add=点击此处添加帐户


### PR DESCRIPTION
2022 年 3 月 10 日起，Mojang 账户不再受支持，必须迁移至微软账户才能登陆。

为了让过渡更平滑，目前暂时保留 Mojang 登陆选项，但是禁止用户使用它进行登陆，并给出迁移提示。