### PR TITLE
加强对 TOKEN 的保护

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LogExporter.java
@@ -65,7 +65,7 @@ public final class LogExporter {
                 }
                 zipper.putTextFile(Logging.getLogs(), "hmcl.log");
                 zipper.putTextFile(logs, "minecraft.log");
-                zipper.putTextFile(launchScript, OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS ? "launch.bat" : "launch.sh");
+                zipper.putTextFile(Logging.filterForbiddenToken(launchScript), OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS ? "launch.bat" : "launch.sh");
 
                 for (String id : versions) {
                     Path versionJson = baseDirectory.resolve("versions").resolve(id).resolve(id + ".json");

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftSession.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/microsoft/MicrosoftSession.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.auth.microsoft;
 
 import org.jackhuang.hmcl.auth.AuthInfo;
+import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
 
 import java.util.Map;
@@ -43,6 +44,8 @@ public class MicrosoftSession {
         this.refreshToken = refreshToken;
         this.user = user;
         this.profile = profile;
+
+        if (accessToken != null) Logging.registerAccessToken(accessToken);
     }
 
     public String getTokenType() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilSession.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilSession.java
@@ -20,6 +20,7 @@ package org.jackhuang.hmcl.auth.yggdrasil;
 import com.google.gson.Gson;
 import org.jackhuang.hmcl.auth.AuthInfo;
 import org.jackhuang.hmcl.util.Immutable;
+import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,6 +47,8 @@ public class YggdrasilSession {
         this.selectedProfile = selectedProfile;
         this.availableProfiles = availableProfiles;
         this.userProperties = userProperties;
+
+        if (accessToken != null) Logging.registerAccessToken(accessToken);
     }
 
     public String getClientToken() {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -47,6 +47,10 @@ public final class Logging {
         forbiddenTokens.put(token, replacement);
     }
 
+    public static void registerAccessToken(String accessToken) {
+        registerForbiddenToken(accessToken, "<access token>");
+    }
+
     public static String filterForbiddenToken(String message) {
         for (Map.Entry<String, String> entry : forbiddenTokens.entrySet()) {
             message = message.replace(entry.getKey(), entry.getValue());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -26,6 +26,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.logging.*;
 
 /**
@@ -38,9 +41,26 @@ public final class Logging {
     public static final Logger LOG = Logger.getLogger("HMCL");
     private static final ByteArrayOutputStream storedLogs = new ByteArrayOutputStream(IOUtils.DEFAULT_BUFFER_SIZE);
 
+    private static final ConcurrentMap<String, String> forbiddenTokens = new ConcurrentHashMap<>();
+
+    public static void registerForbiddenToken(String token, String replacement) {
+        forbiddenTokens.put(token, replacement);
+    }
+
+    public static String filterForbiddenToken(String message) {
+        for (Map.Entry<String, String> entry : forbiddenTokens.entrySet()) {
+            message = message.replace(entry.getKey(), entry.getValue());
+        }
+        return message;
+    }
+
     public static void start(Path logFolder) {
         LOG.setLevel(Level.ALL);
         LOG.setUseParentHandlers(false);
+        LOG.setFilter(record -> {
+            record.setMessage(filterForbiddenToken(record.getMessage()));
+            return true;
+        });
 
         try {
             Files.createDirectories(logFolder);


### PR DESCRIPTION
* #1413：导出的启动脚本中包含敏感信息
* 虽然 `HMCLProcessListener` 过滤了 TOKEN，但 `ProcessExitedAbnormallyEvent` 中记录中依然包含敏感信息。