### PR TITLE
Fix #1405

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/VersionLibraryBuilder.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/VersionLibraryBuilder.java
@@ -51,11 +51,12 @@ public final class VersionLibraryBuilder {
             // Since $ will be escaped in linux, and our maintain of minecraftArgument will not cause escaping,
             // so we regenerate the minecraftArgument without escaping.
             ret = ret.setMinecraftArguments(new CommandBuilder().addAllWithoutParsing(mcArgs).toString());
+        } else {
+            ret = ret.setArguments(ret.getArguments()
+                    .map(args -> args.withGame(game))
+                    .map(args -> jvmChanged ? args.withJvm(jvm) : args).orElse(new Arguments(game, jvmChanged ? jvm : null)));
         }
-        return ret.setArguments(ret.getArguments()
-                .map(args -> args.withGame(game))
-                .map(args -> jvmChanged ? args.withJvm(jvm) : args).orElse(new Arguments(game, jvmChanged ? jvm : null)))
-                .setLibraries(libraries);
+        return ret.setLibraries(libraries);
     }
 
     public boolean hasTweakClass(String tweakClass) {


### PR DESCRIPTION
Fix #1405
修复会生成空的 `arguments.game` 的问题，现在仅当 json 中不存在 `minecraftArguments` 属性时才会对 `arguments` 操作