### PR TITLE
添加 LoongArch64 架构支持

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Architecture.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/Architecture.java
@@ -45,6 +45,7 @@ public enum Architecture {
     S390(BIT_32),
     S390X(BIT_64, "S390x"),
     RISCV(BIT_64, "RISC-V"),
+    LOONGARCH64(BIT_64, "LoongArch64"),
     UNKNOWN(Bits.UNKNOWN, "Unknown");
 
     private final String checkedName;
@@ -168,6 +169,8 @@ public enum Architecture {
                 return S390;
             case "s390x":
                 return S390X;
+            case "loongarch64":
+                return LOONGARCH64;
             default:
                 if (value.startsWith("armv7")) {
                     return ARM32;


### PR DESCRIPTION
本 PR 实现对 LoongArch64 架构的基本支持。

- [x] 识别 `loongarch64` 架构
- [ ] 改进对 LoongArch64 平台用户的提示
- [ ] 支持在 LoongArch64 平台自动补全 JavaFX

目前主要问题在于，龙芯暂未提供新的版本的 OpenJFX 构建，我尝试和龙芯的员工联系解决。