### PR TITLE
Add openjfx to testImplementation dependencies

### DIFF
--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -75,6 +75,7 @@ if (!jfxInClasspath && JavaVersion.current() >= JavaVersion.VERSION_11) {
             rootProject.subprojects {
                 for (module in jfxModules) {
                     dependencies.add("compileOnly", "$groupId:javafx-$module:$version:$classifier")
+                    dependencies.add("testImplementation", "$groupId:javafx-$module:$version:$classifier")
                 }
             }
         }


### PR DESCRIPTION
OpenJFX should be included in `testImplementation` dependencies, otherwise tests won't run on Java 11+.