### PR TITLE
Update java-download.ps1

### DIFF
--- a/HMCLauncher/HMCL/java-download.ps1
+++ b/HMCLauncher/HMCL/java-download.ps1
@@ -79,10 +79,10 @@ if ($result -ne [System.Windows.Forms.DialogResult]::Yes) {
 if ($useMirrorCheckBox.Checked) {
   switch ($Arch) {
       'x86-64' {
-          $script:url = 'https://download.bell-sw.com/java/17.0.2+9/bellsoft-jre17.0.2+9-windows-amd64-full.zip'
+          $script:url = 'http://link.jscdn.cn/lanzou/aHR0cHM6Ly96a2l0ZWZseS5sYW56b3VtLmNvbS9pM0l0YTA0N3ppemEmcGFzc0NvZGU9MDA.zip'
       }
       'x86' {
-          $script:url = 'https://download.bell-sw.com/java/17.0.2+9/bellsoft-jre17.0.2+9-windows-i586-full.zip'
+          $script:url = 'http://link.jscdn.cn/lanzou/aHR0cHM6Ly96a2l0ZWZseS5sYW56b3VtLmNvbS9pZnkzRDA0N3poOGgmcGFzc0NvZGU9MDA.zip'
       }
       default { exit 1 }
   }


### PR DESCRIPTION
使用 蓝奏云 配合 https://link.gimhoy.com/ 获得直链，虽然获得的直链一开始是使用 https 传输的，但程序会在系统不支持 TLS 1.2 时使用 http 来传输，而正巧 蓝奏云 下载链接支持 http 协议，然后就有了这个 PR

![图片](https://user-images.githubusercontent.com/64117916/166432349-a11bcc25-fbe1-4352-a07a-55c05dcb8a30.png)

https://zkitefly.lanzoum.com/ify3D047zh8h
https://zkitefly.lanzoum.com/i3Ita047ziza
密码为：00

