### PR TITLE
fix(config): Use Consolas by default on Windows only

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -43,7 +43,6 @@ import org.jackhuang.hmcl.util.javafx.PropertyUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.Nullable;
 
-
 import java.io.File;
 import java.net.Proxy;
 import java.util.Map;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -146,7 +146,7 @@ public final class Config implements Cloneable, Observable {
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
 
     @SerializedName("fontFamily")
-    private StringProperty fontFamily = new SimpleStringProperty("Consolas");
+    private StringProperty fontFamily = new SimpleStringProperty("Monospace");
 
     @SerializedName("fontSize")
     private DoubleProperty fontSize = new SimpleDoubleProperty(12);
@@ -188,6 +188,10 @@ public final class Config implements Cloneable, Observable {
     private transient ObservableHelper helper = new ObservableHelper(this);
 
     public Config() {
+        // Default override for better-looking logs on Windows
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            this.fontFamily = new SimpleStringProperty("Consolas");
+        }
         PropertyUtils.attachListener(this, helper);
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -190,7 +190,7 @@ public final class Config implements Cloneable, Observable {
     public Config() {
         // Default override for better-looking logs on Windows
         if (System.getProperty("os.name").startsWith("Windows")) {
-            this.fontFamily = new SimpleStringProperty("Consolas");
+            this.fontFamily.setValue("Consolas");
         }
         PropertyUtils.attachListener(this, helper);
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -40,7 +40,9 @@ import org.jackhuang.hmcl.util.i18n.Locales;
 import org.jackhuang.hmcl.util.i18n.Locales.SupportedLocale;
 import org.jackhuang.hmcl.util.javafx.ObservableHelper;
 import org.jackhuang.hmcl.util.javafx.PropertyUtils;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.Nullable;
+
 
 import java.io.File;
 import java.net.Proxy;
@@ -146,7 +148,7 @@ public final class Config implements Cloneable, Observable {
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
 
     @SerializedName("fontFamily")
-    private StringProperty fontFamily = new SimpleStringProperty("Monospace");
+    private StringProperty fontFamily = new SimpleStringProperty(OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS ? "Consolas" : "Monospace");
 
     @SerializedName("fontSize")
     private DoubleProperty fontSize = new SimpleDoubleProperty(12);
@@ -188,10 +190,6 @@ public final class Config implements Cloneable, Observable {
     private transient ObservableHelper helper = new ObservableHelper(this);
 
     public Config() {
-        // Default override for better-looking logs on Windows
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            this.fontFamily.setValue("Consolas");
-        }
         PropertyUtils.attachListener(this, helper);
     }
 


### PR DESCRIPTION
Currently non-Windows systems get a proportional font for logging. Bad.

Fix #139.