### PR TITLE
修复Modrinth源加载列表失败，增加Modrinth源获取前置模组功能

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -19,6 +19,7 @@ package org.jackhuang.hmcl.ui.versions;
 
 import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXScrollPane;
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
@@ -51,6 +52,7 @@ import org.jackhuang.hmcl.ui.construct.*;
 import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.util.SimpleMultimap;
 import org.jackhuang.hmcl.util.StringUtils;
+import org.jackhuang.hmcl.util.function.ExceptionalConsumer;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.jackhuang.hmcl.util.versioning.VersionNumber;
 import org.jetbrains.annotations.Nullable;
@@ -103,9 +105,8 @@ public class DownloadPage extends Control implements DecoratorPage {
         setFailed(false);
 
         Task.allOf(
-                Task.supplyAsync(() -> addon.getData().loadDependencies(repository)),
-                Task.supplyAsync(() -> {
-                    Stream<RemoteMod.Version> versions = addon.getData().loadVersions(repository);
+                        Task.supplyAsync(() -> {
+                            Stream<RemoteMod.Version> versions = addon.getData().loadVersions(repository);
 //                            if (StringUtils.isNotBlank(version.getVersion())) {
 //                                Optional<String> gameVersion = GameVersion.minecraftVersion(versionJar);
 //                                if (gameVersion.isPresent()) {
@@ -113,24 +114,38 @@ public class DownloadPage extends Control implements DecoratorPage {
 //                                            .filter(file -> file.getGameVersions().contains(gameVersion.get())));
 //                                }
 //                            }
-                    return sortVersions(versions);
-                }))
+                            return sortVersions(versions);
+                        }))
                 .whenComplete(Schedulers.javafx(), (result, exception) -> {
                     if (exception == null) {
-                        @SuppressWarnings("unchecked")
-                        List<RemoteMod> dependencies = (List<RemoteMod>) result.get(0);
-                        @SuppressWarnings("unchecked")
-                        SimpleMultimap<String, RemoteMod.Version> versions = (SimpleMultimap<String, RemoteMod.Version>) result.get(1);
 
-                        this.dependencies = dependencies;
+                        @SuppressWarnings("unchecked")
+                        SimpleMultimap<String, RemoteMod.Version> versions = (SimpleMultimap<String, RemoteMod.Version>) result.get(0);
+
                         this.versions = versions;
 
-                        loaded.set(true);
-                        setFailed(false);
+                        ArrayList<RemoteMod.Version> allVersions = new ArrayList<>();
+                        for (String s : versions.keys()) {
+                            allVersions.addAll(versions.get(s));
+                        }
+                        Task.supplyAsync(() -> addon.getData().loadDependencies(repository,allVersions)).thenAcceptAsync((ExceptionalConsumer<List<RemoteMod>, Exception>) remoteMods -> {
+                            this.dependencies = remoteMods;
+                        }).whenComplete(exception1 -> {
+                            Platform.runLater(() -> {
+                                if (exception1 == null) {
+                                    loaded.set(true);
+                                    setFailed(false);
+                                }
+                                else {
+                                    setFailed(true);
+                                }
+                                setLoading(false);
+                            });
+                        }).start();
+
                     } else {
                         setFailed(true);
                     }
-                    setLoading(false);
                 }).start();
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
@@ -90,7 +90,7 @@ public class RemoteMod {
     }
 
     public interface IMod {
-        List<RemoteMod> loadDependencies(RemoteModRepository modRepository) throws IOException;
+        List<RemoteMod> loadDependencies(RemoteModRepository modRepository, List<RemoteMod.Version> versions) throws IOException;
 
         Stream<Version> loadVersions(RemoteModRepository modRepository) throws IOException;
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -179,7 +179,7 @@ public class CurseAddon implements RemoteMod.IMod {
     }
 
     @Override
-    public List<RemoteMod> loadDependencies(RemoteModRepository modRepository) throws IOException {
+    public List<RemoteMod> loadDependencies(RemoteModRepository modRepository, List<RemoteMod.Version> versions) throws IOException {
         Set<Integer> dependencies = latestFiles.stream()
                 .flatMap(latestFile -> latestFile.getDependencies().stream())
                 .filter(dep -> dep.getType() == 3)


### PR DESCRIPTION
Modrinth好了，前置也能加载了，代码写的比较丑陋，Modrinth前置和version塞一块的，所以不能同时获取version和dependency，cf的话。。你自己改了一些了，我也不知哪些改了哪些没改，懒得弄了。。