### PR TITLE
Fixed a typo in Simplified Chinese translation

### DIFF
--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -184,7 +184,7 @@ curse.category.4479=高难度
 curse.category.4482=大型整合包
 curse.category.4472=科技
 curse.category.4473=魔法
-curse.category.5128=香草+
+curse.category.5128=原版增强
 
 # https://addons-ecs.forgesvc.net/api/v2/category/section/6
 curse.category.5299=教育


### PR DESCRIPTION
Vanilla+ should be translated to '原版增强' instead of '香草+'.