### PR TITLE
替换 piston-meta.mojang.com

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/BMCLAPIDownloadProvider.java
@@ -86,6 +86,7 @@ public class BMCLAPIDownloadProvider implements DownloadProvider {
         return baseURL
                 .replace("https://bmclapi2.bangbang93.com", apiRoot)
                 .replace("https://launchermeta.mojang.com", apiRoot)
+                .replace("https://piston-meta.mojang.com", apiRoot)
                 .replace("https://launcher.mojang.com", apiRoot)
                 .replace("https://libraries.minecraft.net", apiRoot + "/libraries")
                 .replaceFirst("https?://files\\.minecraftforge\\.net/maven", apiRoot + "/maven")

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MojangDownloadProvider.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/MojangDownloadProvider.java
@@ -49,7 +49,7 @@ public class MojangDownloadProvider implements DownloadProvider {
 
     @Override
     public String getVersionListURL() {
-        return "https://launchermeta.mojang.com/mc/game/version_manifest.json";
+        return "https://piston-meta.mojang.com/mc/game/version_manifest.json";
     }
 
     @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
@@ -52,7 +52,7 @@ public class JavaDownloadTask extends Task<Void> {
         this.javaVersion = javaVersion;
         this.rootDir = rootDir;
         this.javaDownloadsTask = new GetTask(NetworkUtils.toURL(downloadProvider.injectURL(
-                "https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json")))
+                "https://piston-meta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json")))
         .thenComposeAsync(javaDownloadsJson -> {
             JavaDownloads allDownloads = JsonUtils.fromNonNullJson(javaDownloadsJson, JavaDownloads.class);
             if (!allDownloads.getDownloads().containsKey(platform)) throw new UnsupportedPlatformException();


### PR DESCRIPTION
launchermeta.mojang.com 已经被改为了 piston-meta.mojang.com