### PR TITLE
为快照版添加微软登录支持

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,10 @@ jobs:
         java-package: jdk+fx
     - name: Build with Gradle
       run: ./gradlew build
+      env:
+        MICROSOFT_AUTH_ID: ${{ secrets.MICROSOFT_AUTH_ID }}
+        MICROSOFT_AUTH_SECRET: ${{ secrets.MICROSOFT_AUTH_SECRET }}
+        CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
     - name: Get short SHA
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
     - name: Upload Artifacts


### PR DESCRIPTION
希望黄鱼能在 https://github.com/huanghongxun/HMCL/settings/secrets/actions 中添加下面三个 secrets：`MICROSOFT_AUTH_ID`、`MICROSOFT_AUTH_SECRET` 以及 `CURSEFORGE_API_KEY` ，这样就能使主仓库中 GitHub Action 提供的 DEV 构建也支持微软登录（fork 和 PR 不会读取 secrets，不受影响）。

这样的话，即使没发布新的开发版，依然能从 GitHub Action 中获取全功能的 HMCL，让更多用户及时获取更新内容。
