### PR TITLE
更多平台的原生适配

### DIFF
--- a/HMCL/src/main/resources/assets/natives.json
+++ b/HMCL/src/main/resources/assets/natives.json
@@ -909,7 +909,235 @@
         "linux": "linux-loongarch64"
       }
     },
-    "org.lwjgl:lwjgl:3.3.1:natives-linux": null,
+    "org.lwjgl:lwjgl:3.1.6": {
+      "name": "org.lwjgl:lwjgl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+          "size": 724243
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.1.6:natives": {
+      "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+      "downloads": {
+        "classifiers": {
+          "linux-loongarch64_ow": {
+            "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+            "size": 2311861
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-loongarch64_ow"
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "sha1": "a817bcf213db49f710603677457567c37d53e103",
+          "size": 36601
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": null,
+    "org.lwjgl:lwjgl-openal:3.1.6": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+          "size": 88237
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.1.6:natives": null,
+    "org.lwjgl:lwjgl-opengl:3.1.6": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+          "size": 921563
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.1.6:natives": null,
+    "org.lwjgl:lwjgl-glfw:3.1.6": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+          "size": 128801
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.1.6:natives": null,
+    "org.lwjgl:lwjgl-stb:3.1.6": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+          "size": 112380
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.1.6:natives": null,
+    "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+          "size": 6767
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": null,
+    "org.lwjgl:lwjgl:3.2.2": {
+      "name": "org.lwjgl:lwjgl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+          "size": 724243
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.2.2:natives": {
+      "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+      "downloads": {
+        "classifiers": {
+          "linux-loongarch64_ow": {
+            "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+            "size": 2311861
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-loongarch64_ow"
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "sha1": "a817bcf213db49f710603677457567c37d53e103",
+          "size": 36601
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": null,
+    "org.lwjgl:lwjgl-openal:3.2.2": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+          "size": 88237
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.2.2:natives": null,
+    "org.lwjgl:lwjgl-opengl:3.2.2": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+          "size": 921563
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.2.2:natives": null,
+    "org.lwjgl:lwjgl-glfw:3.2.2": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+          "size": 128801
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.2.2:natives": null,
+    "org.lwjgl:lwjgl-stb:3.2.2": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+          "size": 112380
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.2.2:natives": null,
+    "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+          "size": 6767
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": null,
+    "org.lwjgl:lwjgl:3.3.1:natives-linux": {
+      "name": "org.glavo.hmcl:lwjgl3-natives:3.3.1-rc1",
+      "downloads": {
+        "classifiers": {
+          "linux-loongarch64_ow": {
+            "path": "org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl3-natives/3.3.1-rc1-linux-loongarch64_ow/lwjgl3-natives-3.3.1-rc1-linux-loongarch64_ow.jar",
+            "sha1": "4c7d6978dae411e5041f478d78cc329c4c75fc73",
+            "size": 2311861
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-loongarch64_ow"
+      }
+    },
     "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-linux": null,
     "org.lwjgl:lwjgl-openal:3.3.1:natives-linux": null,
     "org.lwjgl:lwjgl-opengl:3.3.1:natives-linux": null,

--- a/HMCL/src/main/resources/assets/natives.json
+++ b/HMCL/src/main/resources/assets/natives.json
@@ -840,6 +840,70 @@
         }
       }
     },
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+      "downloads": {
+        "classifiers": {
+          "linux-arm32": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+            "size": 580670
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-arm32"
+      }
+    },
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+      "downloads": {
+        "classifiers": {
+          "linux-arm32": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+            "size": 580670
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-arm32"
+      }
+    },
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
+      "downloads": {
+        "classifiers": {
+          "linux-arm32": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-linux-arm32/lwjgl2-natives-2.9.3-linux-arm32.jar",
+            "sha1": "b3017961cf4ff2ce189b64903e52025a88ed9229",
+            "size": 580670
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "linux": "linux-arm32"
+      }
+    },
+    "net.java.jinput:jinput-platform:2.0.5:natives": null,
     "com.mojang:text2speech:1.10.3:natives": null,
     "com.mojang:text2speech:1.11.3:natives": null,
     "com.mojang:text2speech:1.12.4:natives": null,

--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -1,0 +1,46 @@
+# Platform Support Status
+
+|                            | Windows                             | Linux                                   | Mac OS                          | FreeBSD |
+|----------------------------|:------------------------------------|:----------------------------------------|:--------------------------------|:--------|
+| x86-64                     | F                                   | F                                       | F                               | N       |
+| x86                        | F                                   | F                                       | /                               | /       |
+| ARM64                      | P (1.19+)<br/>F (use x86 emulation) | T                                       | P (1.19+)<br/>F (use Rosetta 2) | /       |
+| ARM32                      | /                                   | T                                       | /                               | /       |
+| MIPS64el                   | /                                   | N                                       | /                               | /       |
+| LoongArch64                | /                                   | F (for Old World)<br/>N (for New World) | /                               | /       |
+| PowerPC-64 (Little-Endian) | /                                   | L                                       | /                               | /       |
+| S390x                      | /                                   | L                                       | /                               | /       |
+| RISC-V                     | /                                   | N                                       | /                               | /       |
+
+* F: Fully supported platform.
+
+  Supports all versions of Minecraft, including classic, alpha, beta, official release and snapshot versions.
+
+  Fully supported by Mojang official. Problems encountered in the game should be directly reported to the Mojang.
+
+* Y: Supported platforms.
+
+  All official releases of Minecraft 1.6 and above are supported, snapshot versions may also work.
+
+  Support is provided by HMCL, tested to work, but may have more issues than a fully supported platform.
+  If you encounter a problem that does not exist on fully supported platforms, you can report it to HMCL.
+
+* P: Partially supported platforms.
+
+  Supports some versions of Minecraft, and more versions are still being adapted.
+
+* L: Low level supported platforms.
+
+  HMCL can run on this platform and has some basic support.
+  However, launching the game directly is not yet available.
+  If you want to start the game, 
+  you'll need to get the native libraries needed by Minecraft in other way and specify the native path in the instance settings.
+
+* N: Not currently supported, but plans to support it in the future.
+
+  It is not possible to run HMCL directly on this platform, but we have plans to support it.
+
+* /: Not support.
+
+  We have no plans to support these platforms at this time, mainly because we don't have the equipment to test them.
+  If you can help us adapt, please file a support request via issue.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@
 [![Discord](https://img.shields.io/discord/995291757799538688.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/jVvC7HfM6U)
 [![KOOK](https://img.shields.io/badge/KOOK-HMCL-brightgreen)](https://kook.top/Kx7n3t)
 
-English | [中文](https://github.com/huanghongxun/HMCL/blob/javafx/README_cn.md)
+English | [中文](README_cn.md)
 
 ## Introduction
-HMCL is a Minecraft launcher which supports Mod Management, Game Customizing, Auto Installing (Forge, Fabric, LiteLoader and OptiFine), Modpack Creating, UI Customization, and more.
+HMCL is a cross-platform Minecraft launcher which supports Mod Management, Game Customizing, Auto Installing (Forge, Fabric, LiteLoader and OptiFine), Modpack Creating, UI Customization, and more.
 
-No plugin API is provided.
+HMCL has amazing cross-platform capabilities.
+It can not only run on different operating systems such as Windows, Linux, and Mac OS, 
+but also supports multiple CPU architectures such as x86, arm, mips, and loongarch.
+You can easily play Minecraft on different platforms through HMCL.
+
+For systems and CPU architectures supported by HMCL, see [this table](PLATFORM.md).
 
 ## Download
 Download the latest version from [the official website](https://hmcl.huangyuhui.net/download).

--- a/README_cn.md
+++ b/README_cn.md
@@ -5,12 +5,15 @@
 [![Discord](https://img.shields.io/discord/995291757799538688.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/jVvC7HfM6U)
 [![KOOK](https://img.shields.io/badge/KOOK-HMCL-brightgreen)](https://kook.top/Kx7n3t)
 
-[English](https://github.com/huanghongxun/HMCL/blob/javafx/README.md) | 中文
+[English](README.md) | 中文
 
 ## 简介
-HMCL 是一款 Minecraft 启动器, 支持 Mod 管理, 游戏自定义, 游戏自动安装 (Forge, Fabric, LiteLoader 与 OptiFine), 模组包创建, 界面自定义等功能.
+HMCL 是一款跨平台 Minecraft 启动器, 支持 Mod 管理, 游戏自定义, 游戏自动安装 (Forge, Fabric, LiteLoader 与 OptiFine), 模组包创建, 界面自定义等功能.
 
-不提供插件 API.
+HMCL 有着强大的跨平台能力。它不仅支持 Windows、Linux、Mac OS 等常见的操作系统，同时也支持 x86、ARM、MIPS 和 LoongArch 等不同的 CPU 架构。
+您可以使用 HMCL 在不同平台上轻松的游玩 Minecraft。
+
+如果您想要了解 HMCL 对不同平台的支持程度，请参见[此表格](PLATFORM.md)。
 
 ## 下载
 请从 [HMCL 官网](https://hmcl.huangyuhui.net/download)下载最新版本的 HMCL.


### PR DESCRIPTION
LoongArch64 平台适配基本完成。包括最新的 1.19 在内，Minecraft 高于 1.6 的所有版本都能在龙芯 3A5000 上通过 HMCL 直接启动了。

快照版下载地址：https://github.com/huanghongxun/HMCL/actions/runs/2912397497

![Screenshot 2022-08-23 22-17-24](https://user-images.githubusercontent.com/20694662/186186130-a5c2b6cf-7fb4-459a-9042-c000c6a7b9e4.png)

--- 

在合并之前，本 PR 会继续实现更多平台的原生适配。

已完成列表：
  *  `linux-loongarch64` (1.13+)
  * `linux-arm32` (1.6~1.12.2)