### PR TITLE
修复 HMCL 无法捕获部分异常退出的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
@@ -26,7 +26,9 @@ import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.platform.ManagedProcess;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -58,38 +60,23 @@ final class ExitWaiter implements Runnable {
             for (Thread thread : joins)
                 thread.join();
 
-            ProcessListener.ExitType exitType = null;
-            for (String line : process.getLines()) {
-                Log4jLevel level = Log4jLevel.guessLevel(line);
-                if (Log4jLevel.isError(level)) {
-                    // LaunchWrapper will catch the exception logged and will exit normally.
-                    if (exitCode != 0 && StringUtils.containsOne(line,
-                            "Could not create the Java Virtual Machine.",
-                            "Error occurred during initialization of VM",
-                            "A fatal exception has occurred. Program will exit.")) {
-                        EventBus.EVENT_BUS.fireEvent(new JVMLaunchFailedEvent(this, process));
-                        exitType = ProcessListener.ExitType.JVM_ERROR;
-                        break;
-                    }
+            List<String> errorLines = process.getLines().stream()
+                    .filter(Log4jLevel::guessLogLineError).collect(Collectors.toList());
+            ProcessListener.ExitType exitType;
 
-                    if (exitCode != 0 || StringUtils.containsOne(line, "Unable to launch")) {
-                        EventBus.EVENT_BUS.fireEvent(new ProcessExitedAbnormallyEvent(this, process));
-                        exitType = ProcessListener.ExitType.APPLICATION_ERROR;
-                        break;
-                    }
-                }
-
-                if (level == Log4jLevel.WARN) {
-                    if (StringUtils.containsOne(line, "Failed to create window")) {
-                        EventBus.EVENT_BUS.fireEvent(new ProcessExitedAbnormallyEvent(this, process));
-                        exitType = ProcessListener.ExitType.APPLICATION_ERROR;
-                        break;
-                    }
-                }
-            }
-
-            if (exitType == null)
+            // LaunchWrapper will catch the exception logged and will exit normally.
+            if (exitCode != 0 && StringUtils.containsOne(errorLines,
+                    "Could not create the Java Virtual Machine.",
+                    "Error occurred during initialization of VM",
+                    "A fatal exception has occurred. Program will exit.")) {
+                EventBus.EVENT_BUS.fireEvent(new JVMLaunchFailedEvent(this, process));
+                exitType = ProcessListener.ExitType.JVM_ERROR;
+            } else if (exitCode != 0 || StringUtils.containsOne(errorLines, "Unable to launch")) {
+                EventBus.EVENT_BUS.fireEvent(new ProcessExitedAbnormallyEvent(this, process));
+                exitType = ProcessListener.ExitType.APPLICATION_ERROR;
+            } else {
                 exitType = ProcessListener.ExitType.NORMAL;
+            }
 
             EventBus.EVENT_BUS.fireEvent(new ProcessStoppedEvent(this, process));
 


### PR DESCRIPTION
ExitWaiter 的更改导致某些异常退出无法被 HMCL 捕获，暂时回退了，捕获 OpenGL 版本报错的问题下次跟其他问题一起解决。