### PR TITLE
在 linux-loongarch64 平台自动下载 JavaFX

### DIFF
--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -39,6 +39,7 @@ val jfxPlatforms = listOf(
     Platform("linux-x86_64", "linux"),
     Platform("linux-arm32", "linux-arm32-monocle", unsupportedModules = listOf("media", "web")),
     Platform("linux-arm64", "linux-aarch64"),
+    Platform("linux-loongarch64_ow", "linux", groupId = "org.glavo.hmcl.openjfx", version = "19-ea+10-loongson64"),
 )
 
 val jfxInClasspath =


### PR DESCRIPTION
通过提供自编译的 OpenJFX，支持在 LoongArch64 下自动下载 JavaFX。

![Screenshot 2022-08-29 13-21-06](https://user-images.githubusercontent.com/20694662/187128436-17a12551-c402-407a-9a9a-0041030470f5.png)
