### PR TITLE
添加 Windows on Arm 平台的支持

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -69,12 +69,6 @@ public final class Launcher extends Application {
                 Main.showWarningAndContinue(i18n("fatal.illegal_char"));
             }
 
-            if (!Architecture.CURRENT_ARCH.isX86()
-                    && !(OperatingSystem.CURRENT_OS == OperatingSystem.OSX && Architecture.CURRENT_ARCH == Architecture.ARM64)
-                    && ConfigHolder.globalConfig().getAgreementVersion() < 1) {
-                Main.showWarningAndContinue(i18n("fatal.unsupported_platform"));
-            }
-
             // runLater to ensure ConfigHolder.init() finished initialization
             Platform.runLater(() -> {
                 // When launcher visibility is set to "hide and reopen" without Platform.implicitExit = false,

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/GlobalConfig.java
@@ -68,6 +68,8 @@ public class GlobalConfig implements Cloneable, Observable {
 
     private IntegerProperty agreementVersion = new SimpleIntegerProperty();
 
+    private IntegerProperty platformPromptVersion = new SimpleIntegerProperty();
+
     private StringProperty multiplayerToken = new SimpleStringProperty();
 
     private BooleanProperty multiplayerRelay = new SimpleBooleanProperty();
@@ -113,6 +115,18 @@ public class GlobalConfig implements Cloneable, Observable {
         this.agreementVersion.set(agreementVersion);
     }
 
+    public int getPlatformPromptVersion() {
+        return platformPromptVersion.get();
+    }
+
+    public IntegerProperty platformPromptVersionProperty() {
+        return platformPromptVersion;
+    }
+
+    public void setPlatformPromptVersion(int platformPromptVersion) {
+        this.platformPromptVersion.set(platformPromptVersion);
+    }
+
     public boolean isMultiplayerRelay() {
         return multiplayerRelay.get();
     }
@@ -152,6 +166,7 @@ public class GlobalConfig implements Cloneable, Observable {
     public static class Serializer implements JsonSerializer<GlobalConfig>, JsonDeserializer<GlobalConfig> {
         private static final Set<String> knownFields = new HashSet<>(Arrays.asList(
                 "agreementVersion",
+                "platformPromptVersion",
                 "multiplayerToken",
                 "multiplayerRelay",
                 "multiplayerAgreementVersion"
@@ -165,6 +180,7 @@ public class GlobalConfig implements Cloneable, Observable {
 
             JsonObject jsonObject = new JsonObject();
             jsonObject.add("agreementVersion", context.serialize(src.getAgreementVersion()));
+            jsonObject.add("platformPromptVersion", context.serialize(src.getPlatformPromptVersion()));
             jsonObject.add("multiplayerToken", context.serialize(src.getMultiplayerToken()));
             jsonObject.add("multiplayerRelay", context.serialize(src.isMultiplayerRelay()));
             jsonObject.add("multiplayerAgreementVersion", context.serialize(src.getMultiplayerAgreementVersion()));
@@ -183,6 +199,7 @@ public class GlobalConfig implements Cloneable, Observable {
 
             GlobalConfig config = new GlobalConfig();
             config.setAgreementVersion(Optional.ofNullable(obj.get("agreementVersion")).map(JsonElement::getAsInt).orElse(0));
+            config.setPlatformPromptVersion(Optional.ofNullable(obj.get("platformPromptVersion")).map(JsonElement::getAsInt).orElse(0));
             config.setMultiplayerToken(Optional.ofNullable(obj.get("multiplayerToken")).map(JsonElement::getAsString).orElse(null));
             config.setMultiplayerRelay(Optional.ofNullable(obj.get("multiplayerRelay")).map(JsonElement::getAsBoolean).orElse(false));
             config.setMultiplayerAgreementVersion(Optional.ofNullable(obj.get("multiplayerAgreementVersion")).map(JsonElement::getAsInt).orElse(0));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -53,7 +53,9 @@ import org.jackhuang.hmcl.util.Lazy;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.TaskCancellationAction;
 import org.jackhuang.hmcl.util.io.FileUtils;
+import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.JavaVersion;
+import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.File;
 import java.util.List;
@@ -186,6 +188,19 @@ public final class Controllers {
         stage.setTitle(Metadata.FULL_TITLE);
         stage.initStyle(StageStyle.TRANSPARENT);
         stage.setScene(scene);
+
+        if (!Architecture.SYSTEM_ARCH.isX86() && globalConfig().getPlatformPromptVersion() < 1) {
+            Runnable continueAction = () -> globalConfig().setPlatformPromptVersion(1);
+
+            if (OperatingSystem.CURRENT_OS == OperatingSystem.OSX && Architecture.SYSTEM_ARCH == Architecture.ARM64) {
+                Controllers.dialog(i18n("fatal.unsupported_platform.osx_arm64"), null, MessageType.INFO, continueAction);
+            } else if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS && Architecture.SYSTEM_ARCH == Architecture.ARM64) {
+                Controllers.dialog(i18n("fatal.unsupported_platform.windows_arm64"), null, MessageType.INFO, continueAction);
+            } else {
+                Controllers.dialog(i18n("fatal.unsupported_platform"), null, MessageType.WARNING, continueAction);
+            }
+        }
+
 
         if (globalConfig().getAgreementVersion() < 1) {
             JFXDialogLayout agreementPane = new JFXDialogLayout();

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -364,6 +364,8 @@ fatal.unsupported_platform=Minecraft is not yet fully supported for your platfor
   \n\
   If you can't start Minecraft 1.17 and above, you can try turning on the "Use OpenGL software renderer" option\n\
   in instance settings to use CPU rendering for better compatibility.
+fatal.unsupported_platform.osx_arm64=Minecraft has provided official support for Apple Silicon since 1.19.\NIf you encounter problems when playing versions lower than 1.19, please try to start the game with Java based on x86-64 architecture
+fatal.unsupported_platform.windows_arm64=HMCL has provided native support for the Windows on ARM platform. If you encounter problems when playing game, please try to start the game with Java based on x86 architecture.\n\nIf you are using the <b>Qualcomm</b> platform, you may need to install the <a href="ms-windows-store://pdp/?productid=9NQPSL29BFFF">OpenGL Compatibility Pack</a> before playing games.\nClick the link to go to the Microsoft Store and install the compatibility pack.
 
 feedback=Feedback
 feedback.add=Add a Feedback

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -331,6 +331,8 @@ fatal.apply_update_failure=我們很抱歉 Hello Minecraft! Launcher 無法自�
 fatal.samba=如果您正在通過 Samba 共亯的資料夾中運行 HMCL，HMCL 可能無法正常工作，請嘗試更新您的 Java 或在本地資料夾內運行 HMCL。
 fatal.illegal_char=您的用戶資料夾路徑中存在非法字元‘=’。HMCL 能够運行，但一些功能無法正常使用。 \n您將無法使用外置登入帳戶以及離線登入更換皮膚功能，並且在進行多人遊戲時可能存在更大的安全隱患。
 fatal.unsupported_platform=Minecraft 尚未你您的平臺提供完善支持，所以可能影響遊戲體驗或無法啟動遊戲。\n若無法啟動 Minecraft 1.17 及以上版本，可以嘗試在版本設定中打開“使用 OpenGL 軟渲染器”選項，\n使用 CPU 渲染以獲得更好的相容性。
+fatal.unsupported_platform.osx_arm64=Minecraft 官方從 1.19 開始為 Apple Silicon 提供原生的支持。\n如果你在遊玩低於 1.19 的版本時遇到問題，請嘗試使用 x86-64 架構的 Java 啟動遊戲。
+fatal.unsupported_platform.windows_arm64=HMCL 已為 Windows on Arm 平臺提供原生支持。如果你在遊戲中遭遇問題，請嘗試使用 x86 架構的 Java 啟動遊戲。\n\n如果你正在使用<b>高通</b>平臺，你可能需要安裝 <a href="ms-windows-store://pdp/?productid=9NQPSL29BFFF">OpenGL 相容包</a>後才能進行遊戲。點擊連結前往 Microsoft Store 安裝相容包。
 
 feedback=回饋
 feedback.add=新增回饋

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -331,6 +331,8 @@ fatal.apply_update_failure=我们很抱歉 Hello Minecraft! Launcher 无法自�
 fatal.samba=如果您正在通过 Samba 共享的文件夹中运行 HMCL，HMCL 可能无法正常工作，请尝试更新您的 Java 或在本地文件夹内运行 HMCL。
 fatal.illegal_char=您的用户文件夹路径中存在非法字符‘=’。HMCL 能够运行，但可能某些功能无法正常使用！\n你将无法使用外置登录账户以及离线登录更换皮肤功能，并且在进行多人游戏时可能存在更大的安全隐患！
 fatal.unsupported_platform=Minecraft 尚未为您的平台提供完善支持，所以可能影响游戏体验或无法启动游戏。\n若无法启动 Minecraft 1.17 及以上版本，可以尝试在版本设置中打开“使用 OpenGL 软渲染器”选项，\n使用 CPU 渲染以获得更好的兼容性。
+fatal.unsupported_platform.osx_arm64=Minecraft 官方从 1.19 开始为 Apple Silicon 提供原生的支持。\n如果你在游玩低于 1.19 的版本时遇到问题，请尝试使用 x86-64 架构的 Java 启动游戏。
+fatal.unsupported_platform.windows_arm64=HMCL 已为 Windows on Arm 平台提供原生支持。如果你在游戏中遭遇问题，请尝试使用 x86 架构的 Java 启动游戏。\n\n如果你正在使用<b>高通</b>平台，你可能需要安装 <a href="ms-windows-store://pdp/?productid=9NQPSL29BFFF">OpenGL 兼容包</a>后才能进行游戏。点击链接前往 Microsoft Store 安装兼容包。
 
 feedback=反馈
 feedback.add=新增反馈

--- a/HMCL/src/main/resources/assets/natives.json
+++ b/HMCL/src/main/resources/assets/natives.json
@@ -1228,6 +1228,377 @@
     }
   },
   "windows-arm64": {
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+      "downloads": {
+        "classifiers": {
+          "windows-arm64": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+            "size": 617106
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "windows": "windows-arm64"
+      }
+    },
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.1:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+      "downloads": {
+        "classifiers": {
+          "windows-arm64": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+            "size": 617106
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "windows": "windows-arm64"
+      }
+    },
+    "org.lwjgl.lwjgl:lwjgl-platform:2.9.4-nightly-20150209:natives": {
+      "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3-rc1",
+      "downloads": {
+        "classifiers": {
+          "windows-arm64": {
+            "path": "org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "url": "https://repo1.maven.org/maven2/org/glavo/hmcl/lwjgl2-natives/2.9.3-rc1-windows-arm64/lwjgl2-natives-2.9.3-rc1-windows-arm64.jar",
+            "sha1": "e0948a3692856d47854f3cd5a698d5c0233606d7",
+            "size": 617106
+          }
+        }
+      },
+      "extract": {
+        "exclude": [
+          "META-INF/"
+        ]
+      },
+      "natives": {
+        "windows": "windows-arm64"
+      }
+    },
+    "org.lwjgl:lwjgl:3.1.6": {
+      "name": "org.lwjgl:lwjgl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+          "size": 724243
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar",
+          "sha1": "0f46cadcf95675908fd3a550d63d9d709cb68998",
+          "size": 130064
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.1.6": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "sha1": "a817bcf213db49f710603677457567c37d53e103",
+          "size": 36601
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar",
+          "sha1": "cae85c4edb219c88b6a0c26a87955ad98dc9519d",
+          "size": 114250
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.1.6": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+          "size": 88237
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
+          "sha1": "40d65f1a7368a2aa47336f9cb69f5a190cf9975a",
+          "size": 505234
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.1.6": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+          "size": 921563
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar",
+          "sha1": "527d78f1e9056aff3ed02ce93019c73c5e8f1721",
+          "size": 82445
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.1.6": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+          "size": 128801
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar",
+          "sha1": "beda65ee503443e60aa196d58ed31f8d001dc22a",
+          "size": 123808
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.1.6": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+          "size": 112380
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar",
+          "sha1": "fde63cdd2605c00636721a6c8b961e41d1f6b247",
+          "size": 216848
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.1.6": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+          "size": 6767
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.1.6:natives": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar",
+          "sha1": "83a5e780df610829ff3a737822b4f931cffecd91",
+          "size": 109139
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.2.2": {
+      "name": "org.lwjgl:lwjgl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar",
+          "sha1": "ae58664f88e18a9bb2c77b063833ca7aaec484cb",
+          "size": 724243
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1-natives-windows-arm64.jar",
+          "sha1": "0f46cadcf95675908fd3a550d63d9d709cb68998",
+          "size": 130064
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.2.2": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1.jar",
+          "sha1": "a817bcf213db49f710603677457567c37d53e103",
+          "size": 36601
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.3.1/lwjgl-jemalloc-3.3.1-natives-windows-arm64.jar",
+          "sha1": "cae85c4edb219c88b6a0c26a87955ad98dc9519d",
+          "size": 114250
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.2.2": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1.jar",
+          "sha1": "2623a6b8ae1dfcd880738656a9f0243d2e6840bd",
+          "size": 88237
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.3.1/lwjgl-openal-3.3.1-natives-windows-arm64.jar",
+          "sha1": "40d65f1a7368a2aa47336f9cb69f5a190cf9975a",
+          "size": 505234
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.2.2": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1.jar",
+          "sha1": "831a5533a21a5f4f81bbc51bb13e9899319b5411",
+          "size": 921563
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.3.1/lwjgl-opengl-3.3.1-natives-windows-arm64.jar",
+          "sha1": "527d78f1e9056aff3ed02ce93019c73c5e8f1721",
+          "size": 82445
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.2.2": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1.jar",
+          "sha1": "cbac1b8d30cb4795149c1ef540f912671a8616d0",
+          "size": 128801
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.3.1/lwjgl-glfw-3.3.1-natives-windows-arm64.jar",
+          "sha1": "beda65ee503443e60aa196d58ed31f8d001dc22a",
+          "size": 123808
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.2.2": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1.jar",
+          "sha1": "b119297cf8ed01f247abe8685857f8e7fcf5980f",
+          "size": 112380
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.3.1/lwjgl-stb-3.3.1-natives-windows-arm64.jar",
+          "sha1": "fde63cdd2605c00636721a6c8b961e41d1f6b247",
+          "size": 216848
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.2.2": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+          "sha1": "0ff1914111ef2e3e0110ef2dabc8d8cdaad82347",
+          "size": 6767
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.2.2:natives": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1-natives-windows-arm64.jar",
+          "sha1": "83a5e780df610829ff3a737822b4f931cffecd91",
+          "size": 109139
+        }
+      }
+    },
     "org.lwjgl:lwjgl:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1239,6 +1610,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1250,6 +1622,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-jemalloc:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-openal:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1261,6 +1634,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-openal:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1272,6 +1646,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-opengl:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1283,6 +1658,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-glfw:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-stb:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1294,6 +1670,7 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-stb:3.3.1:natives-windows-x86": null,
     "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows": {
       "name": "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-arm64",
       "downloads": {
@@ -1305,6 +1682,12 @@
         }
       }
     },
+    "org.lwjgl:lwjgl-tinyfd:3.3.1:natives-windows-x86": null,
+    "net.java.jinput:jinput-platform:2.0.5:natives": null,
+    "com.mojang:text2speech:1.10.3:natives": null,
+    "com.mojang:text2speech:1.11.3:natives": null,
+    "com.mojang:text2speech:1.12.4:natives": null,
     "com.mojang:text2speech:1.13.9:natives-windows": null
-  }
+  },
+  "osx-arm64": {}
 }

--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -1,16 +1,16 @@
 # Platform Support Status
 
-|                            | Windows                             | Linux                                   | Mac OS                          | FreeBSD |
-|----------------------------|:------------------------------------|:----------------------------------------|:--------------------------------|:--------|
-| x86-64                     | F                                   | F                                       | F                               | N       |
-| x86                        | F                                   | F                                       | /                               | /       |
-| ARM64                      | P (1.19+)<br/>F (use x86 emulation) | T                                       | P (1.19+)<br/>F (use Rosetta 2) | /       |
-| ARM32                      | /                                   | T                                       | /                               | /       |
-| MIPS64el                   | /                                   | N                                       | /                               | /       |
-| LoongArch64                | /                                   | F (for Old World)<br/>N (for New World) | /                               | /       |
-| PowerPC-64 (Little-Endian) | /                                   | L                                       | /                               | /       |
-| S390x                      | /                                   | L                                       | /                               | /       |
-| RISC-V                     | /                                   | N                                       | /                               | /       |
+|                            | Windows                            | Linux                                   | Mac OS                          | FreeBSD |
+|----------------------------|:-----------------------------------|:----------------------------------------|:--------------------------------|:--------|
+| x86-64                     | F                                  | F                                       | F                               | N       |
+| x86                        | F                                  | F                                       | /                               | /       |
+| ARM64                      | P (1.8+)<br/>F (use x86 emulation) | T                                       | P (1.19+)<br/>F (use Rosetta 2) | /       |
+| ARM32                      | /                                  | T                                       | /                               | /       |
+| MIPS64el                   | /                                  | N                                       | /                               | /       |
+| LoongArch64                | /                                  | F (for Old World)<br/>N (for New World) | /                               | /       |
+| PowerPC-64 (Little-Endian) | /                                  | L                                       | /                               | /       |
+| S390x                      | /                                  | L                                       | /                               | /       |
+| RISC-V                     | /                                  | N                                       | /                               | /       |
 
 * F: Fully supported platform.
 

--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -34,6 +34,7 @@ val jfxDependenciesFile = project("HMCL").buildDir.resolve("openjfx-dependencies
 val jfxPlatforms = listOf(
     Platform("windows-x86", "win-x86"),
     Platform("windows-x86_64", "win"),
+    Platform("windows-arm64", "win", groupId = "org.glavo.hmcl.openjfx", version = "18.0.2+1-arm64", unsupportedModules = listOf("media", "web")),
     Platform("osx-x86_64", "mac"),
     Platform("osx-arm64", "mac-aarch64"),
     Platform("linux-x86_64", "linux"),


### PR DESCRIPTION
功能：

- 在 `windows-arm64` 平台自动补全本机库以实现一键启动；
- 支持在 `windows-arm64`  平台自动下载 JavaFX（官方未提供 WOA 平台 OpenJFX 构建，所以暂时使用我自行发布的版本）；
- 启动时提醒用户安装 OpenGL 兼容包，以避免高通 OpenGL 驱动版本过低的问题。

已知问题：

- 目前 Minecraft 1.6 与 1.7 能够启动，但窗口无法正常渲染；
- Minecraft 1.8~1.12.2 游戏过程中存在一些崩溃的问题；
- 部分版本与 Forge 兼容性不佳。

暂时没精力去解决这些问题，未来我可能会跟进。