### PR TITLE
修改 response.errorDescription.contains() 参数

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -184,6 +184,7 @@ public class OAuth {
                 if (response.errorDescription.contains("The user must sign in again and if needed grant the client application access to the requested scope") ||
                         response.errorDescription.contains("The user must first sign in and grant the client application access to the requested scope") ||
                         response.errorDescription.contains("The user must sign in again") ||
+                        response.errorDescription.contains("The provided value for the input parameter 'refresh_token' or 'assertion' is not valid") ||
                         response.errorDescription.contains("The user could not be authenticated as the grant is expired")) {
                     throw new CredentialExpiredException();
                 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -181,7 +181,7 @@ public class OAuth {
 
         switch (response.error) {
             case "invalid_grant":
-                if (response.errorDescription.contains(".")) {
+                if (response.errorDescription.contains("AADSTS70000")) {
                     throw new CredentialExpiredException();
                 }
                 break;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -182,6 +182,7 @@ public class OAuth {
         switch (response.error) {
             case "invalid_grant":
                 if (response.errorDescription.contains("The user must sign in again and if needed grant the client application access to the requested scope") ||
+                        response.errorDescription.contains("The user must first sign in and grant the client application access to the requested scope") ||
                         response.errorDescription.contains("The user must sign in again") ||
                         response.errorDescription.contains("The provided value for the input parameter 'refresh_token' or 'assertion' is not valid") ||
                         response.errorDescription.contains("The user could not be authenticated as the grant is expired")) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -182,6 +182,8 @@ public class OAuth {
         switch (response.error) {
             case "invalid_grant":
                 if (response.errorDescription.contains("The user must sign in again and if needed grant the client application access to the requested scope") ||
+                        response.errorDescription.contains("The user must first sign in and grant the client application access to the requested scope") ||
+                        response.errorDescription.contains("The user must sign in again") ||
                         response.errorDescription.contains("The user could not be authenticated as the grant is expired")) {
                     throw new CredentialExpiredException();
                 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -181,11 +181,7 @@ public class OAuth {
 
         switch (response.error) {
             case "invalid_grant":
-                if (response.errorDescription.contains("The user must sign in again and if needed grant the client application access to the requested scope") ||
-                        response.errorDescription.contains("The user must first sign in and grant the client application access to the requested scope") ||
-                        response.errorDescription.contains("The user must sign in again") ||
-                        response.errorDescription.contains("The provided value for the input parameter 'refresh_token' or 'assertion' is not valid") ||
-                        response.errorDescription.contains("The user could not be authenticated as the grant is expired")) {
+                if (response.errorDescription.contains(".")) {
                     throw new CredentialExpiredException();
                 }
                 break;

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/OAuth.java
@@ -182,7 +182,6 @@ public class OAuth {
         switch (response.error) {
             case "invalid_grant":
                 if (response.errorDescription.contains("The user must sign in again and if needed grant the client application access to the requested scope") ||
-                        response.errorDescription.contains("The user must first sign in and grant the client application access to the requested scope") ||
                         response.errorDescription.contains("The user must sign in again") ||
                         response.errorDescription.contains("The provided value for the input parameter 'refresh_token' or 'assertion' is not valid") ||
                         response.errorDescription.contains("The user could not be authenticated as the grant is expired")) {


### PR DESCRIPTION
```diff
        switch (response.error) {
            case "invalid_grant":
>                 if (response.errorDescription.contains("AADSTS70000")) {
                    throw new CredentialExpiredException();
                }
```

这样做的好处是一旦出现`invalid_grant`的`AADSTS70000`错误就直接重新登录

AADSTS70000就包括原来的那几个报错，还有我要加的报错