### PR TITLE
修复中文路径下启动 <= 1.12.2 的版本没有声音的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -118,6 +118,11 @@ public class DefaultLauncher extends Launcher {
                 LOG.log(Level.WARNING, "Bad file encoding", ex);
             }
         } else {
+            if (options.getJava().getParsedVersion() > JavaVersion.JAVA_17
+                    && VersionNumber.VERSION_COMPARATOR.compare(repository.getGameVersion(version).orElse("1.13"), "1.13") < 0) {
+                res.addDefault("-Dfile.encoding=", "COMPAT");
+            }
+
             try {
                 String stdoutEncoding = res.addDefault("-Dsun.stdout.encoding=", encoding.name());
                 if (stdoutEncoding != null)

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -108,24 +108,21 @@ public class DefaultLauncher extends Launcher {
 
         res.addAllWithoutParsing(options.getJavaArguments());
 
-        Charset encoding = StandardCharsets.UTF_8;
+        Charset encoding = OperatingSystem.NATIVE_CHARSET;
         if (options.getJava().getParsedVersion() < JavaVersion.JAVA_8) {
             try {
                 String fileEncoding = res.addDefault("-Dfile.encoding=", encoding.name());
                 if (fileEncoding != null)
                     encoding = Charset.forName(fileEncoding.substring("-Dfile.encoding=".length()));
             } catch (Throwable ex) {
-                encoding = OperatingSystem.NATIVE_CHARSET;
                 LOG.log(Level.WARNING, "Bad file encoding", ex);
             }
         } else {
-            res.addDefault("-Dfile.encoding=", "UTF-8");
             try {
                 String stdoutEncoding = res.addDefault("-Dsun.stdout.encoding=", encoding.name());
                 if (stdoutEncoding != null)
                     encoding = Charset.forName(stdoutEncoding.substring("-Dsun.stdout.encoding=".length()));
             } catch (Throwable ex) {
-                encoding = OperatingSystem.NATIVE_CHARSET;
                 LOG.log(Level.WARNING, "Bad stdout encoding", ex);
             }
 


### PR DESCRIPTION
LWJGL2 加载本机库时内部使用 `String::getBytes()` 解码路径，所以依赖于默认编码，将 `file.encoding` 设置为 UTF-8 破坏了本机库加载，导致没有声音。