### PR TITLE
修复在多人联机出现报错时不会回到启动前状态

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerPage.java
@@ -295,7 +295,7 @@ public class MultiplayerPage extends DecoratorAnimatedPage implements DecoratorP
                     break;
             }
 
-//            clearSession();
+            clearSession();
         });
     }
 


### PR DESCRIPTION
不知道为啥 `clearSession();` 参数被注释掉了


https://user-images.githubusercontent.com/64117916/193602502-5a5b5317-9762-4262-ac93-8d858b8f18f3.mp4

