### PR TITLE
在 Linux 上将 HMCL_DIRECTORY 迁移至用户目录中

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
@@ -18,11 +18,9 @@
 package org.jackhuang.hmcl;
 
 import org.jackhuang.hmcl.util.io.JarUtils;
-import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Stores metadata about this application.
@@ -47,20 +45,7 @@ public final class Metadata {
     public static final String BUILD_CHANNEL = JarUtils.thisJar().flatMap(JarUtils::getManifest).map(manifest -> manifest.getMainAttributes().getValue("Build-Channel")).orElse("nightly");
 
     public static final Path MINECRAFT_DIRECTORY = OperatingSystem.getWorkingDirectory("minecraft");
-    public static final Path HMCL_DIRECTORY = getHMCLDirectory();
-
-    private static Path getHMCLDirectory() {
-        String home = System.getProperty("user.home", ".");
-        if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX) {
-            // to fulfill XDG standard.
-            String xdgCache = System.getenv("XDG_CACHE_HOME");
-            if (StringUtils.isNotBlank(xdgCache)) {
-                return Paths.get(xdgCache, "hmcl");
-            }
-            return Paths.get(home, ".cache", "hmcl");
-        }
-        return OperatingSystem.getWorkingDirectory("hmcl");
-    }
+    public static final Path HMCL_DIRECTORY = OperatingSystem.getWorkingDirectory("hmcl");
 
     public static boolean isStable() {
         return "stable".equals(BUILD_CHANNEL);


### PR DESCRIPTION
现在 Linux 上，HMCL 将 HMCL_DIRECTORY 放置在缓存目录中，但缓存目录仅应该存储非关键数据，随时可能被清理，而 HMCL_DIRECTORY 中已经存储了用户的关键数据，所以应该迁移到其他地方。