### PR TITLE
fix IntegrityCheck::performCheck

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadTask.java
@@ -17,6 +17,7 @@
  */
 package org.jackhuang.hmcl.task;
 
+import org.jackhuang.hmcl.util.Hex;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.io.ChecksumMismatchException;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
@@ -25,7 +26,6 @@ import org.jackhuang.hmcl.util.io.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.math.BigInteger;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.FileSystem;
@@ -72,7 +72,7 @@ public class FileDownloadTask extends FetchTask<Void> {
         }
 
         public void performCheck(MessageDigest digest) throws ChecksumMismatchException {
-            String actualChecksum = String.format("%1$040x", new BigInteger(1, digest.digest()));
+            String actualChecksum = Hex.encodeHex(digest.digest());
             if (!checksum.equalsIgnoreCase(actualChecksum)) {
                 throw new ChecksumMismatchException(algorithm, checksum, actualChecksum);
             }


### PR DESCRIPTION
修复 `IntegrityCheck` 无法处理 SHA-256 的问题。