### PR TITLE
修复 MessageDialogPane 总是折叠内容的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -710,6 +710,9 @@ public final class FXUtils {
     }
 
     public static List<Node> parseSegment(String segment, Consumer<String> hyperlinkAction) {
+        if (segment.indexOf('<') < 0)
+            return Collections.singletonList(new Text(segment));
+
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MessageDialogPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/MessageDialogPane.java
@@ -23,8 +23,12 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.TextFlow;
 import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
@@ -69,7 +73,17 @@ public final class MessageDialogPane extends StackPane {
     public MessageDialogPane(@NotNull String text, @Nullable String title, @NotNull MessageType type) {
         FXUtils.loadFXML(this, "/assets/fxml/message-dialog.fxml");
 
-        content.getChildren().setAll(FXUtils.segmentToTextFlow(text, Controllers::onHyperlinkAction));
+        EnhancedTextFlow textFlow = new EnhancedTextFlow();
+        textFlow.getChildren().setAll(FXUtils.parseSegment(text, Controllers::onHyperlinkAction));
+
+        if (textFlow.computePrefHeight(400.0) <= 350.0)
+            content.getChildren().setAll(textFlow);
+        else {
+            ScrollPane scrollPane = new ScrollPane(textFlow);
+            VBox.setVgrow(scrollPane, Priority.ALWAYS);
+            scrollPane.setFitToWidth(true);
+            content.getChildren().setAll(scrollPane);
+        }
 
         if (title != null)
             this.title.setText(title);
@@ -112,6 +126,13 @@ public final class MessageDialogPane extends StackPane {
 
     public ButtonBase getCancelButton() {
         return cancelButton;
+    }
+
+    private static final class EnhancedTextFlow extends TextFlow {
+        @Override
+        public double computePrefHeight(double width) {
+            return super.computePrefHeight(width);
+        }
     }
 
     public static class Builder {

--- a/HMCL/src/main/resources/assets/fxml/message-dialog.fxml
+++ b/HMCL/src/main/resources/assets/fxml/message-dialog.fxml
@@ -1,38 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.*?>
 <?import java.lang.String?>
-<?import javafx.geometry.Insets?>
 <fx:root xmlns="http://javafx.com/javafx"
          xmlns:fx="http://javafx.com/fxml"
          type="StackPane">
-    <BorderPane styleClass="jfx-dialog-layout">
-        <left>
-            <Label fx:id="graphic" translateX="10" translateY="10" minWidth="40" maxWidth="40" minHeight="40" maxHeight="40" />
-        </left>
-        <center>
-            <VBox>
-                <BorderPane.margin>
-                    <Insets left="8" />
-                </BorderPane.margin>
-                <HBox spacing="8">
-                    <StackPane>
-                        <styleClass>
-                            <String fx:value="jfx-layout-heading" />
-                            <String fx:value="title" />
-                        </styleClass>
-                        <Label fx:id="title" text="%message.info" />
-                    </StackPane>
-                </HBox>
-                <ScrollPane VBox.vgrow="ALWAYS" fitToWidth="true" fitToHeight="true">
-                    <StackPane fx:id="content" styleClass="jfx-layout-body" />
-                </ScrollPane>
-            </VBox>
-        </center>
-        <bottom>
-            <HBox fx:id="actions" styleClass="jfx-layout-actions" />
-        </bottom>
-    </BorderPane>
+    <HBox spacing="8" styleClass="jfx-dialog-layout">
+        <Label fx:id="graphic" translateX="10" translateY="10" minWidth="40" maxWidth="40" minHeight="40"
+               maxHeight="40"/>
+        <VBox HBox.hgrow="ALWAYS">
+            <StackPane>
+                <styleClass>
+                    <String fx:value="jfx-layout-heading"/>
+                    <String fx:value="title"/>
+                </styleClass>
+                <Label fx:id="title" text="%message.info"/>
+            </StackPane>
+            <StackPane fx:id="content" styleClass="jfx-layout-body"/>
+            <HBox fx:id="actions" styleClass="jfx-layout-actions"/>
+        </VBox>
+    </HBox>
 </fx:root>


### PR DESCRIPTION
似乎没有干净的做法来实现，我就用 hack 一点的方式来做了。

@huanghongxun 这个 PR 很重要，修复了非常影响使用体验的问题，希望合并本 PR 并重新编译 HMCLauncher.exe 后，立即发布新版本。