### PR TITLE
因 #1807 , 将地址广播功能隐藏

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/multiplayer/MultiplayerPageSkin.java
@@ -307,9 +307,9 @@ public class MultiplayerPageSkin extends DecoratorAnimatedPage.DecoratorAnimated
 
                         FXUtils.onChangeAndOperate(control.broadcasterProperty(), broadcaster -> {
                             if (broadcaster == null) {
-                                slavePane.getChildren().setAll(titlePane, hintPane, hintPane2, notBroadcastingPane);
+                                slavePane.getChildren().setAll(titlePane, hintPane);//, hintPane2, notBroadcastingPane);
                             } else {
-                                slavePane.getChildren().setAll(titlePane, hintPane, hintPane2, broadcastingPane);
+                                slavePane.getChildren().setAll(titlePane, hintPane);//, hintPane2, broadcastingPane);
                             }
                         });
                     }


### PR DESCRIPTION
https://github.com/huanghongxun/HMCL/commit/a70e53364d519dcaa191682f832809cb79358bb3 是直接让离线账户能够加入世界，就已经完美的解决了因为正版认证加入不了房间的问题

**而且地址广播功能也有些问题，例如加入一次房间后，再加入一次会加入失败并显示“连接终止”**

本PR仅隐藏地址广播功能的入口，**并没有删除**，这样做也是不想修改更多东西

@huanghongxun 希望能看一下