### PR TITLE
性能与内存优化

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/LauncherHelper.java
@@ -742,7 +742,7 @@ public final class LauncherHelper {
         private boolean lwjgl;
         private LogWindow logWindow;
         private final boolean detectWindow;
-        private final LinkedList<Pair<String, Log4jLevel>> logs;
+        private final ArrayDeque<Pair<String, Log4jLevel>> logs;
         private final CountDownLatch logWindowLatch = new CountDownLatch(1);
         private final CountDownLatch launchingLatch;
 
@@ -753,7 +753,7 @@ public final class LauncherHelper {
             this.launchingLatch = launchingLatch;
             this.detectWindow = detectWindow;
 
-            logs = new LinkedList<>();
+            this.logs = new ArrayDeque<>(config().getLogLines() + 1);
         }
 
         @Override

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -85,9 +85,9 @@ public class GameCrashWindow extends Stage {
     private final LaunchOptions launchOptions;
     private final View view;
 
-    private final List<Pair<String, Log4jLevel>> logs;
+    private final Collection<Pair<String, Log4jLevel>> logs;
 
-    public GameCrashWindow(ManagedProcess managedProcess, ProcessListener.ExitType exitType, DefaultGameRepository repository, Version version, LaunchOptions launchOptions, List<Pair<String, Log4jLevel>> logs) {
+    public GameCrashWindow(ManagedProcess managedProcess, ProcessListener.ExitType exitType, DefaultGameRepository repository, Version version, LaunchOptions launchOptions, Collection<Pair<String, Log4jLevel>> logs) {
         this.managedProcess = managedProcess;
         this.exitType = exitType;
         this.repository = repository;

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/WeakListenerHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/WeakListenerHolder.java
@@ -24,11 +24,11 @@ import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.WeakListChangeListener;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 public class WeakListenerHolder {
-    private List<Object> refs = new LinkedList<>();
+    private final List<Object> refs = new ArrayList<>(0);
 
     public WeakListenerHolder() {
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultCacheRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/DefaultCacheRepository.java
@@ -95,7 +95,7 @@ public class DefaultCacheRepository extends CacheRepository {
             LibraryDownloadInfo info = library.getDownload();
             String hash = info.getSha1();
             if (hash != null) {
-                String checksum = Hex.encodeHex(DigestUtils.digest("SHA-1", jar));
+                String checksum = DigestUtils.digestToString("SHA-1", jar);
                 if (hash.equalsIgnoreCase(checksum))
                     cacheLibrary(library, jar, false);
             } else if (library.getChecksums() != null && !library.getChecksums().isEmpty()) {
@@ -148,7 +148,7 @@ public class DefaultCacheRepository extends CacheRepository {
         if (Files.exists(jar)) {
             try {
                 if (hash != null) {
-                    String checksum = Hex.encodeHex(DigestUtils.digest("SHA-1", jar));
+                    String checksum = DigestUtils.digestToString("SHA-1", jar);
                     if (hash.equalsIgnoreCase(checksum))
                         return Optional.of(restore(jar, () -> cacheLibrary(library, jar, false)));
                 } else if (library.getChecksums() != null && !library.getChecksums().isEmpty()) {
@@ -177,7 +177,7 @@ public class DefaultCacheRepository extends CacheRepository {
     public Path cacheLibrary(Library library, Path path, boolean forge) throws IOException {
         String hash = library.getDownload().getSha1();
         if (hash == null)
-            hash = Hex.encodeHex(DigestUtils.digest(SHA1, path));
+            hash = DigestUtils.digestToString(SHA1, path);
 
         Path cache = getFile(SHA1, hash);
         FileUtils.copyFile(path.toFile(), cache.toFile());

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeNewInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/forge/ForgeNewInstallTask.java
@@ -32,6 +32,7 @@ import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.task.FileDownloadTask.IntegrityCheck;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.function.ExceptionalFunction;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -59,8 +60,6 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.zip.ZipException;
 
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.gson.JsonUtils.fromNonNullJson;
 
@@ -99,7 +98,7 @@ public class ForgeNewInstallTask extends Task<Version> {
                 if (Files.exists(artifact)) {
                     String code;
                     try (InputStream stream = Files.newInputStream(artifact)) {
-                        code = encodeHex(digest("SHA-1", stream));
+                        code = (DigestUtils.digestToString("SHA-1", stream));
                     }
 
                     if (!Objects.equals(code, value)) {
@@ -167,7 +166,7 @@ public class ForgeNewInstallTask extends Task<Version> {
 
                 String code;
                 try (InputStream stream = Files.newInputStream(artifact)) {
-                    code = encodeHex(digest("SHA-1", stream));
+                    code = DigestUtils.digestToString("SHA-1", stream);
                 }
 
                 if (!Objects.equals(code, entry.getValue())) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetIndexDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/GameAssetIndexDownloadTask.java
@@ -25,7 +25,6 @@ import org.jackhuang.hmcl.game.Version;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.util.DigestUtils;
-import org.jackhuang.hmcl.util.Hex;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -79,7 +78,7 @@ public final class GameAssetIndexDownloadTask extends Task<Void> {
             // verify correctness of file content
             if (verifyHashCode) {
                 try {
-                    String actualSum = Hex.encodeHex(DigestUtils.digest("SHA-1", assetIndexFile));
+                    String actualSum = DigestUtils.digestToString("SHA-1", assetIndexFile);
                     if (actualSum.equalsIgnoreCase(assetIndexInfo.getSha1()))
                         return;
                 } catch (IOException e) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/LibraryDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/game/LibraryDownloadTask.java
@@ -25,6 +25,7 @@ import org.jackhuang.hmcl.task.DownloadException;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.FileDownloadTask.IntegrityCheck;
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.Pack200Utils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.io.IOUtils;
@@ -43,8 +44,6 @@ import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 import java.util.logging.Level;
 
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 
 public class LibraryDownloadTask extends Task<Void> {
@@ -181,7 +180,7 @@ public class LibraryDownloadTask extends Task<Void> {
                 return true;
             }
             byte[] fileData = Files.readAllBytes(libPath.toPath());
-            boolean valid = checksums.contains(encodeHex(digest("SHA-1", fileData)));
+            boolean valid = checksums.contains(DigestUtils.digestToString("SHA-1", fileData));
             if (!valid && libPath.getName().endsWith(".jar")) {
                 valid = validateJar(fileData, checksums);
             }
@@ -203,7 +202,7 @@ public class LibraryDownloadTask extends Task<Void> {
                 hashes = new String(eData, StandardCharsets.UTF_8).split("\n");
             }
             if (!entry.isDirectory()) {
-                files.put(entry.getName(), encodeHex(digest("SHA-1", eData)));
+                files.put(entry.getName(), DigestUtils.digestToString("SHA-1", eData));
             }
             entry = jar.getNextJarEntry();
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/AssetObject.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/AssetObject.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.game;
 
 import com.google.gson.JsonParseException;
 import org.jackhuang.hmcl.util.DigestUtils;
-import org.jackhuang.hmcl.util.Hex;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.Validation;
 
@@ -64,6 +63,6 @@ public final class AssetObject implements Validation {
 
     public boolean validateChecksum(Path file, boolean defaultValue) throws IOException {
         if (hash == null) return defaultValue;
-        return Hex.encodeHex(DigestUtils.digest("SHA-1", file)).equalsIgnoreCase(hash);
+        return DigestUtils.digestToString("SHA-1", file).equalsIgnoreCase(hash);
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DownloadInfo.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/DownloadInfo.java
@@ -83,6 +83,6 @@ public class DownloadInfo implements Validation {
 
     public boolean validateChecksum(Path file, boolean defaultValue) throws IOException {
         if (getSha1() == null) return defaultValue;
-        return Hex.encodeHex(DigestUtils.digest("SHA-1", file)).equalsIgnoreCase(getSha1());
+        return DigestUtils.digestToString("SHA-1", file).equalsIgnoreCase(getSha1());
     }
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ExitWaiter.java
@@ -28,7 +28,6 @@ import org.jackhuang.hmcl.util.platform.ManagedProcess;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 /**
  *
@@ -60,8 +59,7 @@ final class ExitWaiter implements Runnable {
             for (Thread thread : joins)
                 thread.join();
 
-            List<String> errorLines = process.getLines().stream()
-                    .filter(Log4jLevel::guessLogLineError).collect(Collectors.toList());
+            List<String> errorLines = process.getLines(Log4jLevel::guessLogLineError);
             ProcessListener.ExitType exitType;
 
             // LaunchWrapper will catch the exception logged and will exit normally.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/MinecraftInstanceTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/MinecraftInstanceTask.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.mod;
 
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.CompressingUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -30,9 +31,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 
 public final class MinecraftInstanceTask<T> extends Task<ModpackConfiguration<T>> {
 
@@ -69,7 +67,7 @@ public final class MinecraftInstanceTask<T> extends Task<ModpackConfiguration<T>
                         @Override
                         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                             String relativePath = root.relativize(file).normalize().toString().replace(File.separatorChar, '/');
-                            overrides.add(new ModpackConfiguration.FileInformation(relativePath, encodeHex(digest("SHA-1", file))));
+                            overrides.add(new ModpackConfiguration.FileInformation(relativePath, DigestUtils.digestToString("SHA-1", file)));
                             return FileVisitResult.CONTINUE;
                         }
                     });

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackInstallTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModpackInstallTask.java
@@ -18,6 +18,7 @@
 package org.jackhuang.hmcl.mod;
 
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.io.Unzipper;
 
@@ -27,9 +28,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.function.Predicate;
-
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 
 public class ModpackInstallTask<T> extends Task<Void> {
 
@@ -93,7 +91,7 @@ public class ModpackInstallTask<T> extends Task<Void> {
                         } else {
                             // If both old and new modpacks have this entry, and user has modified this file,
                             // we will not replace it since this modified file is what user expects.
-                            String fileHash = encodeHex(digest("SHA-1", destPath));
+                            String fileHash = DigestUtils.digestToString("SHA-1", destPath);
                             String oldHash = files.get(entryPath).getHash();
                             return Objects.equals(oldHash, fileHash);
                         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackCompletionTask.java
@@ -26,6 +26,7 @@ import org.jackhuang.hmcl.mod.ModpackConfiguration;
 import org.jackhuang.hmcl.mod.ModpackCompletionException;
 import org.jackhuang.hmcl.mod.curse.CurseMetaMod;
 import org.jackhuang.hmcl.task.*;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -49,8 +50,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 import static org.jackhuang.hmcl.util.Lang.wrap;
 import static org.jackhuang.hmcl.util.Lang.wrapConsumer;
 
@@ -138,7 +137,7 @@ public class McbbsModpackCompletionTask extends CompletableFutureTask<Void> {
                         } else if (getFileHash(file) != null) {
                             // If user modified this entry file, we will not replace this file since this modified file is what user expects.
                             // Or we have downloaded latest file in previous completion task, this time we have no need to download it again.
-                            String fileHash = encodeHex(digest("SHA-1", actualPath));
+                            String fileHash = DigestUtils.digestToString("SHA-1", actualPath);
                             String oldHash = getFileHash(oldFile);
                             String newHash = getFileHash(file);
                             if (oldHash == null) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/mcbbs/McbbsModpackExportTask.java
@@ -27,6 +27,7 @@ import org.jackhuang.hmcl.mod.curse.CurseManifest;
 import org.jackhuang.hmcl.mod.curse.CurseManifestMinecraft;
 import org.jackhuang.hmcl.mod.curse.CurseManifestModLoader;
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -41,8 +42,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.*;
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 
 public class McbbsModpackExportTask extends Task<Void> {
     private final DefaultGameRepository repository;
@@ -75,7 +74,7 @@ public class McbbsModpackExportTask extends Task<Void> {
                     Path file = runDirectory.resolve(path);
                     if (Files.isRegularFile(file)) {
                         String relativePath = runDirectory.relativize(file).normalize().toString().replace(File.separatorChar, '/');
-                        files.add(new McbbsModpackManifest.AddonFile(true, relativePath, encodeHex(digest("SHA-1", file))));
+                        files.add(new McbbsModpackManifest.AddonFile(true, relativePath, DigestUtils.digestToString("SHA-1", file)));
                     }
                     return true;
                 } else {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -98,7 +98,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
 
     @Override
     public Optional<RemoteMod.Version> getRemoteVersionByLocalFile(LocalModFile localModFile, Path file) throws IOException {
-        String sha1 = Hex.encodeHex(DigestUtils.digest("SHA-1", file));
+        String sha1 = DigestUtils.digestToString("SHA-1", file);
 
         try {
             ProjectVersion mod = HttpRequest.GET(PREFIX + "/v2/version_file/" + sha1,

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackCompletionTask.java
@@ -26,6 +26,7 @@ import org.jackhuang.hmcl.mod.ModpackConfiguration;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.GetTask;
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -41,9 +42,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 
 public class ServerModpackCompletionTask extends Task<Void> {
 
@@ -149,7 +147,7 @@ public class ServerModpackCompletionTask extends Task<Void> {
                 download = true;
             } else {
                 // If user modified this entry file, we will not replace this file since this modified file is that user expects.
-                String fileHash = encodeHex(digest("SHA-1", actualPath));
+                String fileHash = DigestUtils.digestToString("SHA-1", actualPath);
                 String oldHash = files.get(file.getPath()).getHash();
                 download = !Objects.equals(oldHash, file.getHash()) && Objects.equals(oldHash, fileHash);
             }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackExportTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/server/ServerModpackExportTask.java
@@ -24,6 +24,7 @@ import org.jackhuang.hmcl.mod.Modpack;
 import org.jackhuang.hmcl.mod.ModpackConfiguration;
 import org.jackhuang.hmcl.mod.ModpackExportInfo;
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.util.DigestUtils;
 import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
@@ -37,8 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.jackhuang.hmcl.download.LibraryAnalyzer.LibraryType.*;
-import static org.jackhuang.hmcl.util.DigestUtils.digest;
-import static org.jackhuang.hmcl.util.Hex.encodeHex;
 
 public class ServerModpackExportTask extends Task<Void> {
     private final DefaultGameRepository repository;
@@ -71,7 +70,7 @@ public class ServerModpackExportTask extends Task<Void> {
                     Path file = runDirectory.resolve(path);
                     if (Files.isRegularFile(file)) {
                         String relativePath = runDirectory.relativize(file).normalize().toString().replace(File.separatorChar, '/');
-                        files.add(new ModpackConfiguration.FileInformation(relativePath, encodeHex(digest("SHA-1", file))));
+                        files.add(new ModpackConfiguration.FileInformation(relativePath, DigestUtils.digestToString("SHA-1", file)));
                     }
                     return true;
                 } else {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/CacheRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/CacheRepository.java
@@ -111,7 +111,7 @@ public class CacheRepository {
         Path file = getFile(algorithm, hash);
         if (Files.exists(file)) {
             try {
-                return Hex.encodeHex(DigestUtils.digest(algorithm, file)).equalsIgnoreCase(hash);
+                return DigestUtils.digestToString(algorithm, file).equalsIgnoreCase(hash);
             } catch (IOException e) {
                 return false;
             }
@@ -139,7 +139,7 @@ public class CacheRepository {
         if (original != null && Files.exists(original)) {
             if (hash != null) {
                 try {
-                    String checksum = Hex.encodeHex(DigestUtils.digest(algorithm, original));
+                    String checksum = DigestUtils.digestToString(algorithm, original);
                     if (checksum.equalsIgnoreCase(hash))
                         return Optional.of(restore(original, () -> cacheFile(original, algorithm, hash)));
                 } catch (IOException e) {
@@ -173,7 +173,7 @@ public class CacheRepository {
         if (StringUtils.isBlank(eTagItem.hash) || !fileExists(SHA1, eTagItem.hash)) throw new FileNotFoundException();
         Path file = getFile(SHA1, eTagItem.hash);
         if (Files.getLastModifiedTime(file).toMillis() != eTagItem.localLastModified) {
-            String hash = Hex.encodeHex(DigestUtils.digest(SHA1, file));
+            String hash = DigestUtils.digestToString(SHA1, file);
             if (!Objects.equals(hash, eTagItem.hash))
                 throw new IOException("This file is modified");
         }
@@ -208,7 +208,7 @@ public class CacheRepository {
 
     public void cacheRemoteFile(Path downloaded, URLConnection conn) throws IOException {
         cacheData(() -> {
-            String hash = Hex.encodeHex(DigestUtils.digest(SHA1, downloaded));
+            String hash = DigestUtils.digestToString(SHA1, downloaded);
             Path cached = cacheFile(downloaded, SHA1, hash);
             return new CacheResult(hash, cached);
         }, conn);
@@ -220,7 +220,7 @@ public class CacheRepository {
 
     public void cacheBytes(byte[] bytes, URLConnection conn) throws IOException {
         cacheData(() -> {
-            String hash = Hex.encodeHex(DigestUtils.digest(SHA1, bytes));
+            String hash = DigestUtils.digestToString(SHA1, bytes);
             Path cached = getFile(SHA1, hash);
             FileUtils.writeBytes(cached.toFile(), bytes);
             return new CacheResult(hash, cached);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/DigestUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/DigestUtils.java
@@ -24,8 +24,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  *
  * @author huangyuhui
@@ -43,10 +41,6 @@ public final class DigestUtils {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException(e);
         }
-    }
-
-    public static byte[] digest(String algorithm, String data) {
-        return digest(algorithm, data.getBytes(UTF_8));
     }
 
     public static byte[] digest(String algorithm, byte[] data) {
@@ -67,8 +61,22 @@ public final class DigestUtils {
         return updateDigest(digest, data).digest();
     }
 
+    public static String digestToString(String algorithm, byte[] data) throws IOException {
+        return Hex.encodeHex(digest(algorithm, data));
+    }
+
+    public static String digestToString(String algorithm, Path path) throws IOException {
+        return Hex.encodeHex(digest(algorithm, path));
+    }
+
+    public static String digestToString(String algorithm, InputStream data) throws IOException {
+        return Hex.encodeHex(digest(algorithm, data));
+    }
+
+    private static final ThreadLocal<byte[]> threadLocalBuffer = ThreadLocal.withInitial(() -> new byte[STREAM_BUFFER_LENGTH]);
+
     public static MessageDigest updateDigest(MessageDigest digest, InputStream data) throws IOException {
-        byte[] buffer = new byte[STREAM_BUFFER_LENGTH];
+        byte[] buffer = threadLocalBuffer.get();
         int read = data.read(buffer, 0, STREAM_BUFFER_LENGTH);
 
         while (read > -1) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/ChecksumMismatchException.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/ChecksumMismatchException.java
@@ -19,7 +19,6 @@ package org.jackhuang.hmcl.util.io;
 
 import org.jackhuang.hmcl.download.ArtifactMalformedException;
 import org.jackhuang.hmcl.util.DigestUtils;
-import org.jackhuang.hmcl.util.Hex;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -50,7 +49,7 @@ public class ChecksumMismatchException extends ArtifactMalformedException {
     }
 
     public static void verifyChecksum(Path file, String algorithm, String expectedChecksum) throws IOException {
-        String checksum = Hex.encodeHex(DigestUtils.digest(algorithm, file));
+        String checksum = DigestUtils.digestToString(algorithm, file);
         if (!checksum.equalsIgnoreCase(expectedChecksum)) {
             throw new ChecksumMismatchException(algorithm, expectedChecksum, checksum);
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
@@ -22,7 +22,6 @@ import org.jackhuang.hmcl.util.Lang;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 
 /**
@@ -38,7 +37,7 @@ public class ManagedProcess {
     private final List<String> commands;
     private final String classpath;
     private final Map<String, Object> properties = new HashMap<>();
-    private final Queue<String> lines = new ConcurrentLinkedQueue<>();
+    private final List<String> lines = new ArrayList<>();
     private final List<Thread> relatedThreads = new ArrayList<>();
 
     public ManagedProcess(ProcessBuilder processBuilder) throws IOException {
@@ -116,7 +115,7 @@ public class ManagedProcess {
         return Collections.unmodifiableCollection(lines);
     }
 
-    public void addLine(String line) {
+    public synchronized void addLine(String line) {
         lines.add(line);
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/ManagedProcess.java
@@ -23,6 +23,7 @@ import org.jackhuang.hmcl.util.Lang;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 /**
  * The managed process.
@@ -111,8 +112,16 @@ public class ManagedProcess {
      *
      * @see #addLine
      */
-    public Collection<String> getLines() {
-        return Collections.unmodifiableCollection(lines);
+    public synchronized List<String> getLines(Predicate<String> lineFilter) {
+        if (lineFilter == null)
+            return Collections.unmodifiableList(Arrays.asList(lines.toArray(new String[0])));
+
+        ArrayList<String> res = new ArrayList<>();
+        for (String line : this.lines) {
+            if (lineFilter.test(line))
+                res.add(line);
+        }
+        return Collections.unmodifiableList(res);
     }
 
     public synchronized void addLine(String line) {


### PR DESCRIPTION
* 通过使用 `ThreadLocal` 复用 `DigestUtils.updateDigest` 中分配的 buffer，能够在每次启动 HMCL 时减少约 2200 次内存分配，少分配数 MiB 内存，缓解 GC 压力，也能轻微降低启动时的 CPU 占用；
* 通过在 IntegrityChecker 中共享 MessageDigest，能够在每次启动时减少约 4400 个新 MessageDigest 的分配，轻微缓解 GC 压力和降低 CPU 占用；
* 根据用户反馈，长时间运行 Minecraft 后 HMCL 内存会持续增长，这里尝试将剩余的部分 LinkedList 用法更换为 ArrayList，理论上长时间运行时能节约 MiB 级别的内存，轻微缓解内存占用问题，我也会继续尝试分析其他内存泄漏问题。