### PR TITLE
Update GitHub Action

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -8,15 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
-          java-package: jdk+fx
+          java-package: 'jdk+fx'
       - name: Check style main
         run: ./gradlew checkstyleMain
       - name: Check style test

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -8,14 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '11'
-          java-package: jdk+fx
+          java-package: 'jdk+fx'
       - name: Check style test
         run: ./gradlew checkTranslations

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -10,7 +10,7 @@ jobs:
     if: ${{ github.repository_owner == 'huanghongxun' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Fetch tags
         run: git fetch --all --tags
       - name: Install tools

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,15 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Checkout submodules
-      run: git submodule update --init --recursive
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: '11'
-        java-package: jdk+fx
+        java-package: 'jdk+fx'
     - name: Build with Gradle
       run: ./gradlew build
       env:
@@ -26,7 +24,7 @@ jobs:
     - name: Get short SHA
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: HMCL-${{ env.SHORT_SHA }}
         path: HMCL/build/libs


### PR DESCRIPTION
`actions/setup-java@v2`、`actions/upload-artifact@v2` 和 `actions/checkout@v2` 已经被弃用，应更新至 v3。