### PR TITLE
修复 Java 18+ Minecraft 日志乱码的问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -109,30 +109,16 @@ public class DefaultLauncher extends Launcher {
         res.addAllWithoutParsing(options.getJavaArguments());
 
         Charset encoding = OperatingSystem.NATIVE_CHARSET;
-        if (options.getJava().getParsedVersion() < JavaVersion.JAVA_8) {
+        String fileEncoding = res.addDefault("-Dfile.encoding=", encoding.name());
+        if (fileEncoding != null && !"-Dfile.encoding=COMPAT".equals(fileEncoding)) {
             try {
-                String fileEncoding = res.addDefault("-Dfile.encoding=", encoding.name());
-                if (fileEncoding != null)
-                    encoding = Charset.forName(fileEncoding.substring("-Dfile.encoding=".length()));
+                encoding = Charset.forName(fileEncoding.substring("-Dfile.encoding=".length()));
             } catch (Throwable ex) {
                 LOG.log(Level.WARNING, "Bad file encoding", ex);
             }
-        } else {
-            if (options.getJava().getParsedVersion() > JavaVersion.JAVA_17
-                    && VersionNumber.VERSION_COMPARATOR.compare(repository.getGameVersion(version).orElse("1.13"), "1.13") < 0) {
-                res.addDefault("-Dfile.encoding=", "COMPAT");
-            }
-
-            try {
-                String stdoutEncoding = res.addDefault("-Dsun.stdout.encoding=", encoding.name());
-                if (stdoutEncoding != null)
-                    encoding = Charset.forName(stdoutEncoding.substring("-Dsun.stdout.encoding=".length()));
-            } catch (Throwable ex) {
-                LOG.log(Level.WARNING, "Bad stdout encoding", ex);
-            }
-
-            res.addDefault("-Dsun.stderr.encoding=", encoding.name());
         }
+        res.addDefault("-Dsun.stdout.encoding=", encoding.name());
+        res.addDefault("-Dsun.stderr.encoding=", encoding.name());
 
         // JVM Args
         if (!options.isNoGeneratedJVMArgs()) {


### PR DESCRIPTION
由于 Log4j 将 `System.out` 作为字节流处理，绕过了 `System.out` 本身的编码而使用默认编码进行输出，导致 Java 18+ 上默认使用 UTF-8 进行日志，最后造成乱码。

将 `file.encoding` 默认设置为本机编码可以解决这一点。