### PR TITLE
Optimization HMCLProcessListener::onLog

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -42,6 +42,7 @@ import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.construct.TwoLineListItem;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Log4jLevel;
+import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.Pair;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.CommandBuilder;
@@ -222,7 +223,7 @@ public class GameCrashWindow extends Stage {
     private void showLogWindow() {
         LogWindow logWindow = new LogWindow();
 
-        logWindow.logLine("Command: " + new CommandBuilder().addAll(managedProcess.getCommands()).toString(), Log4jLevel.INFO);
+        logWindow.logLine(Logging.filterForbiddenToken("Command: " + new CommandBuilder().addAll(managedProcess.getCommands())), Log4jLevel.INFO);
         if (managedProcess.getClasspath() != null) logWindow.logLine("ClassPath: " + managedProcess.getClasspath(), Log4jLevel.INFO);
         for (Map.Entry<String, Log4jLevel> entry : logs)
             logWindow.logLine(entry.getKey(), entry.getValue());

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -37,7 +37,6 @@ import javafx.stage.Stage;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.jackhuang.hmcl.game.LauncherHelper;
 import org.jackhuang.hmcl.util.Log4jLevel;
-import org.jackhuang.hmcl.util.Logging;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.io.IOException;
@@ -95,8 +94,8 @@ public final class LogWindow extends Stage {
         levelShownMap.values().forEach(property -> property.addListener((a, b, newValue) -> shakeLogs()));
     }
 
-    public void logLine(String line, Log4jLevel level) {
-        Log log = new Log(Logging.filterForbiddenToken(parseEscapeSequence(line)), level);
+    public void logLine(String filteredLine, Log4jLevel level) {
+        Log log = new Log(parseEscapeSequence(filteredLine), level);
         logs.add(log);
         if (levelShownMap.get(level).get())
             impl.listView.getItems().add(log);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -21,7 +21,6 @@ import org.jackhuang.hmcl.auth.AuthInfo;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.game.*;
 import org.jackhuang.hmcl.util.Lang;
-import org.jackhuang.hmcl.util.Log4jLevel;
 import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.gson.UUIDTypeAdapter;
 import org.jackhuang.hmcl.util.io.FileUtils;
@@ -646,15 +645,15 @@ public class DefaultLauncher extends Launcher {
             throw new ExecutionPolicyLimitException();
     }
 
-    private void startMonitors(ManagedProcess managedProcess, ProcessListener processListener, Charset encoding, boolean isDaemon) {
+    private static void startMonitors(ManagedProcess managedProcess, ProcessListener processListener, Charset encoding, boolean isDaemon) {
         processListener.setProcess(managedProcess);
         Thread stdout = Lang.thread(new StreamPump(managedProcess.getProcess().getInputStream(), it -> {
-            processListener.onLog(it, Optional.ofNullable(Log4jLevel.guessLevel(it)).orElse(Log4jLevel.INFO));
+            processListener.onLog(it, false);
             managedProcess.addLine(it);
         }, encoding), "stdout-pump", isDaemon);
         managedProcess.addRelatedThread(stdout);
         Thread stderr = Lang.thread(new StreamPump(managedProcess.getProcess().getErrorStream(), it -> {
-            processListener.onLog(it, Log4jLevel.ERROR);
+            processListener.onLog(it, true);
             managedProcess.addLine(it);
         }, encoding), "stderr-pump", isDaemon);
         managedProcess.addRelatedThread(stderr);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ProcessListener.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/ProcessListener.java
@@ -17,7 +17,6 @@
  */
 package org.jackhuang.hmcl.launch;
 
-import org.jackhuang.hmcl.util.Log4jLevel;
 import org.jackhuang.hmcl.util.platform.ManagedProcess;
 
 /**
@@ -40,7 +39,7 @@ public interface ProcessListener {
      *
      * @param log the log
      */
-    void onLog(String log, Log4jLevel level);
+    void onLog(String log, boolean isErrorStream);
 
     /**
      * Called when the game process stops.

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Lang.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Lang.java
@@ -366,6 +366,13 @@ public final class Lang {
         return () -> iterator;
     }
 
+    public static <T, U> void forEachZipped(Iterable<T> i1, Iterable<U> i2, BiConsumer<T, U> action) {
+        Iterator<T> it1 = i1.iterator();
+        Iterator<U> it2 = i2.iterator();
+        while (it1.hasNext() && it2.hasNext())
+            action.accept(it1.next(), it2.next());
+    }
+
     private static Timer timer;
 
     public static synchronized Timer getTimer() {


### PR DESCRIPTION
HMCL 隐藏窗口后，作为后台进程，应该尽可能地降低性能与内存开销，以防干扰游戏表现。

目前 HMCL 监控游戏进程 stdout/stderr 的 `StreamPump` callback 开销尚不可忽略，可能轻微阻塞游戏进程的日志输出。

本 PR 通过细化锁粒度与惰性猜测日志级别，使其**开销降低约 1/2**，同时减少后台内存分配，降低开销。