### PR TITLE
延迟提交 JFXTextField 的变化

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -132,7 +132,7 @@ public class DownloadSettingsPage extends StackPane {
 
                     JFXTextField threadsField = new JFXTextField();
                     FXUtils.setLimitWidth(threadsField, 60);
-                    threadsField.textProperty().bindBidirectional(config().downloadThreadsProperty(), SafeStringConverter.fromInteger());
+                    FXUtils.bindInt(threadsField, config().downloadThreadsProperty());
 
                     AtomicBoolean changedByTextField = new AtomicBoolean(false);
                     FXUtils.onChangeAndOperate(config().downloadThreadsProperty(), value -> {
@@ -213,7 +213,7 @@ public class DownloadSettingsPage extends StackPane {
                         GridPane.setRowIndex(txtProxyHost, 1);
                         GridPane.setColumnIndex(txtProxyHost, 1);
                         gridPane.getChildren().add(txtProxyHost);
-                        txtProxyHost.textProperty().bindBidirectional(config().proxyHostProperty());
+                        FXUtils.bindString(txtProxyHost, config().proxyHostProperty());
                         txtProxyHost.getValidators().setAll(new NumberValidator(i18n("input.number"), false));
                     }
 
@@ -232,11 +232,10 @@ public class DownloadSettingsPage extends StackPane {
                         FXUtils.setValidateWhileTextChanged(txtProxyPort, true);
                         gridPane.getChildren().add(txtProxyPort);
 
-                        txtProxyPort.textProperty().bindBidirectional(config().proxyPortProperty(),
-                                SafeStringConverter.fromInteger()
-                                        .restrict(it -> it >= 0 && it <= 0xFFFF)
-                                        .fallbackTo(0)
-                                        .asPredicate(Validator.addTo(txtProxyPort)));
+                        FXUtils.bind(txtProxyPort, config().proxyPortProperty(), SafeStringConverter.fromInteger()
+                                .restrict(it -> it >= 0 && it <= 0xFFFF)
+                                .fallbackTo(0)
+                                .asPredicate(Validator.addTo(txtProxyPort)));
                     }
                     proxyPane.getChildren().add(gridPane);
                 }
@@ -273,7 +272,7 @@ public class DownloadSettingsPage extends StackPane {
                         GridPane.setRowIndex(txtProxyUsername, 0);
                         GridPane.setColumnIndex(txtProxyUsername, 1);
                         authPane.getChildren().add(txtProxyUsername);
-                        txtProxyUsername.textProperty().bindBidirectional(config().proxyUserProperty());
+                        FXUtils.bindString(txtProxyUsername, config().proxyUserProperty());
                     }
 
                     {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -146,12 +146,10 @@ public class PersonalizationPage extends StackPane {
 
                         JFXTextField txtLogFontSize = new JFXTextField();
                         FXUtils.setLimitWidth(txtLogFontSize, 50);
-                        txtLogFontSize.textProperty().bindBidirectional(config().fontSizeProperty(),
-                                SafeStringConverter.fromFiniteDouble()
-                                        .restrict(it -> it > 0)
-                                        .fallbackTo(12.0)
-                                        .asPredicate(Validator.addTo(txtLogFontSize)));
-
+                        FXUtils.bind(txtLogFontSize, config().fontSizeProperty(), SafeStringConverter.fromFiniteDouble()
+                                .restrict(it -> it > 0)
+                                .fallbackTo(12.0)
+                                .asPredicate(Validator.addTo(txtLogFontSize)));
 
                         hBox.getChildren().setAll(cboLogFont, txtLogFontSize);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -43,7 +43,6 @@ import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Pair;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
-import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.JavaVersion;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
@@ -259,7 +258,7 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
                     JFXTextField txtMaxMemory = new JFXTextField();
                     FXUtils.setLimitWidth(txtMaxMemory, 60);
                     FXUtils.setValidateWhileTextChanged(txtMaxMemory, true);
-                    txtMaxMemory.textProperty().bindBidirectional(maxMemory, SafeStringConverter.fromInteger());
+                    FXUtils.bindInt(txtMaxMemory, maxMemory);
                     txtMaxMemory.setValidators(new NumberValidator(i18n("input.number"), false));
 
                     lowerBoundPane.getChildren().setAll(label, slider, txtMaxMemory, new Label("MB"));
@@ -628,19 +627,19 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
 
         // unbind data fields
         if (lastVersionSetting != null) {
-            FXUtils.unbindInt(txtWidth, lastVersionSetting.widthProperty());
-            FXUtils.unbindInt(txtHeight, lastVersionSetting.heightProperty());
+            FXUtils.unbind(txtWidth, lastVersionSetting.widthProperty());
+            FXUtils.unbind(txtHeight, lastVersionSetting.heightProperty());
             maxMemory.unbindBidirectional(lastVersionSetting.maxMemoryProperty());
             javaCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.javaDirProperty());
             gameDirCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.gameDirProperty());
             nativesDirCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.nativesDirProperty());
-            FXUtils.unbindString(txtJVMArgs, lastVersionSetting.javaArgsProperty());
-            FXUtils.unbindString(txtGameArgs, lastVersionSetting.minecraftArgsProperty());
-            FXUtils.unbindString(txtMetaspace, lastVersionSetting.permSizeProperty());
-            FXUtils.unbindString(txtWrapper, lastVersionSetting.wrapperProperty());
-            FXUtils.unbindString(txtPreLaunchCommand, lastVersionSetting.preLaunchCommandProperty());
-            FXUtils.unbindString(txtPostExitCommand, lastVersionSetting.postExitCommandProperty());
-            FXUtils.unbindString(txtServerIP, lastVersionSetting.serverIpProperty());
+            FXUtils.unbind(txtJVMArgs, lastVersionSetting.javaArgsProperty());
+            FXUtils.unbind(txtGameArgs, lastVersionSetting.minecraftArgsProperty());
+            FXUtils.unbind(txtMetaspace, lastVersionSetting.permSizeProperty());
+            FXUtils.unbind(txtWrapper, lastVersionSetting.wrapperProperty());
+            FXUtils.unbind(txtPreLaunchCommand, lastVersionSetting.preLaunchCommandProperty());
+            FXUtils.unbind(txtPostExitCommand, lastVersionSetting.postExitCommandProperty());
+            FXUtils.unbind(txtServerIP, lastVersionSetting.serverIpProperty());
             FXUtils.unbindBoolean(chkAutoAllocate, lastVersionSetting.autoMemoryProperty());
             FXUtils.unbindBoolean(chkFullscreen, lastVersionSetting.fullscreenProperty());
             noGameCheckPane.selectedProperty().unbindBidirectional(lastVersionSetting.notCheckGameProperty());


### PR DESCRIPTION
* 在 `JFXTextField` 失去焦点时提交内容变化，避免在用户键入时不断地写入配置文件
* 校验 `JFXTextField` 的值，拒绝提交非法值并回滚

已测试以下场景以确保用户的修改总是能正确触发 `JFXTextField` 失去焦点事件：

- [x] 修改完毕后点击此页面其他位置
- [x] 修改完毕后直接点击返回
- [x] 修改完毕后切换至其他标签页
- [x] 修改完毕后直接退出 HMCL