### PR TITLE
Replace ObservableMap with MapProperty

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -141,7 +141,7 @@ public final class Config implements Cloneable, Observable {
     private StringProperty versionListSource = new SimpleStringProperty("balanced");
 
     @SerializedName("configurations")
-    private ObservableMap<String, Profile> configurations = FXCollections.observableMap(new TreeMap<>());
+    private SimpleMapProperty<String, Profile> configurations = new SimpleMapProperty<>(FXCollections.observableMap(new TreeMap<>()));
 
     @SerializedName("accounts")
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
@@ -476,7 +476,7 @@ public final class Config implements Cloneable, Observable {
         return versionListSource;
     }
 
-    public ObservableMap<String, Profile> getConfigurations() {
+    public MapProperty<String, Profile> getConfigurations() {
         return configurations;
     }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profiles.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Profiles.java
@@ -20,6 +20,7 @@ package org.jackhuang.hmcl.setting;
 import javafx.application.Platform;
 import javafx.beans.Observable;
 import javafx.beans.property.*;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.event.EventBus;
@@ -29,8 +30,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static javafx.collections.FXCollections.observableArrayList;
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
@@ -130,8 +131,11 @@ public final class Profiles {
         if (!initialized)
             return;
         // update storage
-        config().getConfigurations().clear();
-        config().getConfigurations().putAll(profiles.stream().collect(Collectors.toMap(Profile::getName, it -> it)));
+        TreeMap<String, Profile> newConfigurations = new TreeMap<>();
+        for (Profile profile : profiles) {
+            newConfigurations.put(profile.getName(), profile);
+        }
+        config().getConfigurations().setValue(FXCollections.observableMap(newConfigurations));
     }
 
     /**


### PR DESCRIPTION
对普通的 ObservableMap 进行修改时，每修改一个值都会触发一次 invalid 事件，导致对每个 Profile 内容进行修改时，都会触发 `2 * Profile 总数` 次 invalid 事件（调用 `clear` 时为会为每个元素触发一次事件，调用 `putAll` 时又会触发一遍），反复进行保存。

将其更换为 `MapProperty` 后，每次 `set` 只会触发一次 invalid 事件。