### PR TITLE
修复 Java 下载相关问题

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/download/java/JavaDownloadTask.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -99,7 +100,7 @@ public class JavaDownloadTask extends Task<Void> {
                     task.setName(entry.getKey());
                     dependencies.add(task.thenRunAsync(() -> {
                         try (LZMAInputStream input = new LZMAInputStream(new FileInputStream(tempFile))) {
-                            Files.copy(input, dest);
+                            Files.copy(input, dest, StandardCopyOption.REPLACE_EXISTING);
                         } catch (IOException e) {
                             throw new ArtifactMalformedException("File " + entry.getKey() + " is malformed", e);
                         }


### PR DESCRIPTION
* 修复文件已存在时无法通过校验的报错
* 使用镜像源下载 Java
* 跳过已经存在的文件