### PR TITLE
修复内存泄漏

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -141,10 +141,16 @@ public final class Controllers {
     }
 
     public static void onApplicationStop() {
-        config().setHeight(stageHeight.get());
-        config().setWidth(stageWidth.get());
-        stageHeight = null;
-        stageWidth = null;
+        if (stageHeight != null) {
+            config().setHeight(stageHeight.get());
+            stageHeight.unbind();
+            stageHeight = null;
+        }
+        if (stageWidth != null) {
+            config().setWidth(stageWidth.get());
+            stageWidth.unbind();
+            stageWidth = null;
+        }
     }
 
     public static void initialize(Stage stage) {
@@ -321,5 +327,6 @@ public final class Controllers {
         decorator = null;
         stage = null;
         scene = null;
+        onApplicationStop();
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/VersionsPage.java
@@ -127,7 +127,8 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
         btnRefresh.setGraphic(wrap(SVG.refresh(Theme.blackFillBinding(), -1, -1)));
 
         MutableObject<RemoteVersionListCell> lastCell = new MutableObject<>();
-        list.setCellFactory(listView -> new RemoteVersionListCell(lastCell));
+        EnumMap<VersionIconType, Image> icons = new EnumMap<>(VersionIconType.class);
+        list.setCellFactory(listView -> new RemoteVersionListCell(lastCell, icons));
 
         list.setOnMouseClicked(e -> {
             if (list.getSelectionModel().getSelectedIndex() < 0)
@@ -218,27 +219,24 @@ public final class VersionsPage extends BorderPane implements WizardPage, Refres
     }
 
     private static class RemoteVersionListCell extends ListCell<RemoteVersion> {
-        private static final EnumMap<VersionIconType, Image> icon = new EnumMap<>(VersionIconType.class);
-
-        private static Image getIcon(VersionIconType type) {
-            assert Platform.isFxApplicationThread();
-            return icon.computeIfAbsent(type, iconType -> new Image(iconType.getResourceUrl(), 32, 32, false, true));
-        }
-
         final IconedTwoLineListItem content = new IconedTwoLineListItem();
         final RipplerContainer ripplerContainer = new RipplerContainer(content);
         final StackPane pane = new StackPane();
 
         private final MutableObject<RemoteVersionListCell> lastCell;
+        private final EnumMap<VersionIconType, Image> icons;
 
-        RemoteVersionListCell(MutableObject<RemoteVersionListCell> lastCell) {
+        RemoteVersionListCell(MutableObject<RemoteVersionListCell> lastCell, EnumMap<VersionIconType, Image> icons) {
             this.lastCell = lastCell;
-        }
+            this.icons = icons;
 
-        {
             pane.getStyleClass().add("md-list-cell");
             StackPane.setMargin(content, new Insets(10, 16, 10, 16));
             pane.getChildren().setAll(ripplerContainer);
+        }
+
+        private Image getIcon(VersionIconType type) {
+            return icons.computeIfAbsent(type, iconType -> new Image(iconType.getResourceUrl(), 32, 32, false, true));
         }
 
         @Override

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/CompressingUtils.java
@@ -87,7 +87,7 @@ public final class CompressingUtils {
     }
 
     public static Charset findSuitableEncoding(Path zipFile) throws IOException {
-        return findSuitableEncoding(zipFile, Charset.availableCharsets().values());
+        return findSuitableEncoding(zipFile, null);
     }
 
     public static Charset findSuitableEncoding(Path zipFile, Collection<Charset> candidates) throws IOException {
@@ -97,13 +97,16 @@ public final class CompressingUtils {
     }
 
     public static Charset findSuitableEncoding(ZipFile zipFile) throws IOException {
-        return findSuitableEncoding(zipFile, Charset.availableCharsets().values());
+        return findSuitableEncoding(zipFile, null);
     }
 
     public static Charset findSuitableEncoding(ZipFile zipFile, Collection<Charset> candidates) throws IOException {
         if (testEncoding(zipFile, StandardCharsets.UTF_8)) return StandardCharsets.UTF_8;
         if (OperatingSystem.NATIVE_CHARSET != StandardCharsets.UTF_8 && testEncoding(zipFile, OperatingSystem.NATIVE_CHARSET))
             return OperatingSystem.NATIVE_CHARSET;
+
+        if (candidates == null)
+            candidates = Charset.availableCharsets().values();
 
         for (Charset charset : candidates)
             if (charset != null && testEncoding(zipFile, charset))
@@ -155,8 +158,6 @@ public final class CompressingUtils {
         public FileSystem build() throws IOException {
             if (autoDetectEncoding) {
                 if (!testEncoding(zip, encoding)) {
-                    if (charsetCandidates == null)
-                        charsetCandidates = Charset.availableCharsets().values();
                     encoding = findSuitableEncoding(zip, charsetCandidates);
                 }
             }


### PR DESCRIPTION
现在 HMCL 依然有一些内存泄漏问题，本 PR 尝试继续解决它们。

- [x] 修复 `Controllers` 中 `stageWidth`/`stageHeight` 泄露的内存
  * 降低 10~20MiB 启动游戏后的内存占用
          ![image](https://user-images.githubusercontent.com/20694662/204783816-1f65998e-9de5-4a93-ae5e-322f1443cf8f.png)
- [x] 避免静态缓存图标
