### PR TITLE
修复在精简 JRE 上崩溃的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/SelfDependencyPatcher.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toSet;
@@ -102,14 +103,26 @@ public final class SelfDependencyPatcher {
         private static final Path DEPENDENCIES_DIR_PATH = HMCL_DIRECTORY.resolve("dependencies").resolve(Platform.getPlatform().toString()).resolve("openjfx");
 
         static List<DependencyDescriptor> readDependencies() {
+            ArrayList<DependencyDescriptor> dependencies;
             //noinspection ConstantConditions
             try (Reader reader = new InputStreamReader(SelfDependencyPatcher.class.getResourceAsStream(DEPENDENCIES_LIST_FILE), UTF_8)) {
-                Map<String, List<DependencyDescriptor>> allDependencies =
-                        new Gson().fromJson(reader, new TypeToken<Map<String, List<DependencyDescriptor>>>(){}.getType());
-                return allDependencies.get(Platform.getPlatform().toString());
+                Map<String, ArrayList<DependencyDescriptor>> allDependencies =
+                        new Gson().fromJson(reader, new TypeToken<Map<String, ArrayList<DependencyDescriptor>>>(){}.getType());
+                dependencies = allDependencies.get(Platform.getPlatform().toString());
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+
+            try {
+                ClassLoader classLoader = SelfDependencyPatcher.class.getClassLoader();
+                Class.forName("netscape.javascript.JSObject", false, classLoader);
+                Class.forName("org.w3c.dom.html.HTMLDocument", false, classLoader);
+            } catch (Throwable e) {
+                LOG.log(Level.WARNING, "Disable javafx.web because JRE is incomplete", e);
+                dependencies.removeIf(it -> "javafx.web".equals(it.module) || "javafx.media".equals(it.module));
+            }
+
+            return dependencies;
         }
 
         public String module;


### PR DESCRIPTION
- [x] 当模块 `jdk.jsobject` 或 `jdk.xml.dom` 不存在时，不加载 `javafx.web`。
- [x] 修复 `jdk.zipfs` 不存在时程序崩溃的问题。

本 PR 修复后，HMCL 能够在仅包含 `java.se` 和 `jdk.unsupported` 的 JRE 上运行。当 `jdk.zipfs` 缺失时不会崩溃，但会影响正常启动。