### PR TITLE
修复主题相关问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -40,7 +40,6 @@ import org.jackhuang.hmcl.util.i18n.Locales;
 import org.jackhuang.hmcl.util.i18n.Locales.SupportedLocale;
 import org.jackhuang.hmcl.util.javafx.ObservableHelper;
 import org.jackhuang.hmcl.util.javafx.PropertyUtils;
-import org.jackhuang.hmcl.util.platform.OperatingSystem;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
@@ -147,7 +146,7 @@ public final class Config implements Cloneable, Observable {
     private ObservableList<Map<Object, Object>> accountStorages = FXCollections.observableArrayList();
 
     @SerializedName("fontFamily")
-    private StringProperty fontFamily = new SimpleStringProperty(OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS ? "Consolas" : "Monospace");
+    private StringProperty fontFamily = new SimpleStringProperty();
 
     @SerializedName("fontSize")
     private DoubleProperty fontSize = new SimpleDoubleProperty(12);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Config.java
@@ -120,7 +120,7 @@ public final class Config implements Cloneable, Observable {
     private DoubleProperty height = new SimpleDoubleProperty();
 
     @SerializedName("theme")
-    private ObjectProperty<Theme> theme = new SimpleObjectProperty<>(Theme.BLUE);
+    private ObjectProperty<Theme> theme = new SimpleObjectProperty<>();
 
     @SerializedName("localization")
     private ObjectProperty<SupportedLocale> localization = new SimpleObjectProperty<>(Locales.DEFAULT);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -29,6 +29,7 @@ import org.jackhuang.hmcl.util.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -120,25 +121,35 @@ public class Theme {
     public static Optional<Theme> getTheme(String name) {
         if (name == null)
             return Optional.empty();
-        else if (name.equalsIgnoreCase("blue"))
-            return Optional.of(BLUE);
-        else if (name.equalsIgnoreCase("darker_blue"))
-            return Optional.of(custom("#283593"));
-        else if (name.equalsIgnoreCase("green"))
-            return Optional.of(custom("#43A047"));
-        else if (name.equalsIgnoreCase("orange"))
-            return Optional.of(custom("#E67E22"));
-        else if (name.equalsIgnoreCase("purple"))
-            return Optional.of(custom("#9C27B0"));
-        else if (name.equalsIgnoreCase("red"))
-            return Optional.of(custom("#F44336"));
-
-        if (name.startsWith("#"))
+        else if (name.startsWith("#"))
             try {
                 Color.web(name);
                 return Optional.of(custom(name));
             } catch (IllegalArgumentException ignore) {
             }
+        else {
+            String color = null;
+            switch (name.toLowerCase(Locale.ROOT)) {
+                case "blue":
+                    return Optional.of(BLUE);
+                case "darker_blue":
+                    color = "#283593";
+                    break;
+                case "green":
+                    color = "#43A047";
+                    break;
+                case "orange":
+                    color = "#E67E22";
+                    break;
+                case "purple":
+                    color = "#9C27B0";
+                    break;
+                case "red":
+                    color = "#F44336";
+            }
+            if (color != null)
+                return Optional.of(new Theme(name, color));
+        }
 
         return Optional.empty();
     }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/Theme.java
@@ -86,10 +86,10 @@ public class Theme {
     public String[] getStylesheets(String overrideFontFamily) {
         String css = "/assets/css/blue.css";
 
-        Color textFill = getForegroundColor();
         String fontFamily = System.getProperty("hmcl.font.override", overrideFontFamily);
 
-        if (true) {
+        if (fontFamily != null || !this.color.equalsIgnoreCase(BLUE.color)) {
+            Color textFill = getForegroundColor();
             try {
                 File temp = File.createTempFile("hmcl", ".css");
                 FileUtils.writeText(temp, IOUtils.readFullyAsString(Theme.class.getResourceAsStream("/assets/css/custom.css"))

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/Controllers.java
@@ -35,6 +35,7 @@ import org.jackhuang.hmcl.game.ModpackHelper;
 import org.jackhuang.hmcl.setting.Accounts;
 import org.jackhuang.hmcl.setting.EnumCommonDirectory;
 import org.jackhuang.hmcl.setting.Profiles;
+import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.task.Task;
 import org.jackhuang.hmcl.task.TaskExecutor;
 import org.jackhuang.hmcl.ui.account.AccountListPage;
@@ -181,7 +182,7 @@ public final class Controllers {
         stage.setMinWidth(800 + 2 + 16); // bg width + border width*2 + shadow width*2
         decorator.getDecorator().prefWidthProperty().bind(scene.widthProperty());
         decorator.getDecorator().prefHeightProperty().bind(scene.heightProperty());
-        scene.getStylesheets().setAll(config().getTheme().getStylesheets(config().getLauncherFontFamily()));
+        scene.getStylesheets().setAll(Theme.getTheme().getStylesheets(config().getLauncherFontFamily()));
 
         stage.getIcons().add(newImage("/assets/img/icon.png"));
         stage.setTitle(Metadata.FULL_TITLE);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -94,6 +94,8 @@ public final class FXUtils {
     private FXUtils() {
     }
 
+    public static String DEFAULT_MONOSPACE_FONT = OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS ? "Consolas" : "Monospace";
+
     public static void runInFX(Runnable runnable) {
         if (Platform.isFxApplicationThread()) {
             runnable.run();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/GameCrashWindow.java
@@ -38,6 +38,7 @@ import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.download.LibraryAnalyzer;
 import org.jackhuang.hmcl.game.*;
 import org.jackhuang.hmcl.launch.ProcessListener;
+import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.ui.construct.TwoLineListItem;
 import org.jackhuang.hmcl.util.Lang;
@@ -107,7 +108,7 @@ public class GameCrashWindow extends Stage {
         this.feedbackTextFlow.getChildren().addAll(FXUtils.parseSegment(i18n("game.crash.feedback"), Controllers::onHyperlinkAction));
 
         setScene(new Scene(view, 800, 480));
-        getScene().getStylesheets().addAll(config().getTheme().getStylesheets(config().getLauncherFontFamily()));
+        getScene().getStylesheets().addAll(Theme.getTheme().getStylesheets(config().getLauncherFontFamily()));
         setTitle(i18n("game.crash.title"));
         getIcons().add(newImage("/assets/img/icon.png"));
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -289,9 +289,8 @@ public final class LogWindow extends Stage {
                         listView.scrollTo(listView.getItems().size() - 1);
                 });
 
-                String fontFamily = Lang.requireNonNullElse(config().getFontFamily(), FXUtils.DEFAULT_MONOSPACE_FONT);
-
-                listView.setStyle("-fx-font-family: " + fontFamily + "; -fx-font-size: " + config().getFontSize() + "px;");
+                listView.setStyle("-fx-font-family: " + Lang.requireNonNullElse(config().getFontFamily(), FXUtils.DEFAULT_MONOSPACE_FONT)
+                        + "; -fx-font-size: " + config().getFontSize() + "px;");
                 MutableObject<Object> lastCell = new MutableObject<>();
                 listView.setCellFactory(x -> new ListCell<Log>() {
                     {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -36,6 +36,7 @@ import javafx.scene.layout.*;
 import javafx.stage.Stage;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.jackhuang.hmcl.game.LauncherHelper;
+import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.util.Log4jLevel;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
@@ -87,7 +88,7 @@ public final class LogWindow extends Stage {
 
     public LogWindow() {
         setScene(new Scene(impl, 800, 480));
-        getScene().getStylesheets().addAll(config().getTheme().getStylesheets(config().getLauncherFontFamily()));
+        getScene().getStylesheets().addAll(Theme.getTheme().getStylesheets(config().getLauncherFontFamily()));
         setTitle(i18n("logwindow.title"));
         getIcons().add(newImage("/assets/img/icon.png"));
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -37,6 +37,7 @@ import javafx.stage.Stage;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.jackhuang.hmcl.game.LauncherHelper;
 import org.jackhuang.hmcl.setting.Theme;
+import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Log4jLevel;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
@@ -287,7 +288,10 @@ public final class LogWindow extends Stage {
                     if (!listView.getItems().isEmpty() && control.autoScroll.get())
                         listView.scrollTo(listView.getItems().size() - 1);
                 });
-                listView.setStyle("-fx-font-family: " + config().getFontFamily() + "; -fx-font-size: " + config().getFontSize() + "px;");
+
+                String fontFamily = Lang.requireNonNullElse(config().getFontFamily(), FXUtils.DEFAULT_MONOSPACE_FONT);
+
+                listView.setStyle("-fx-font-family: " + fontFamily + "; -fx-font-size: " + config().getFontSize() + "px;");
                 MutableObject<Object> lastCell = new MutableObject<>();
                 listView.setCellFactory(x -> new ListCell<Log>() {
                     {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/WebStage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/WebStage.java
@@ -26,6 +26,7 @@ import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import org.jackhuang.hmcl.Metadata;
+import org.jackhuang.hmcl.setting.Theme;
 
 import static org.jackhuang.hmcl.setting.ConfigHolder.config;
 import static org.jackhuang.hmcl.ui.FXUtils.newImage;
@@ -42,7 +43,7 @@ public class WebStage extends Stage {
 
     public WebStage(int width, int height) {
         setScene(new Scene(pane, width, height));
-        getScene().getStylesheets().addAll(config().getTheme().getStylesheets(config().getLauncherFontFamily()));
+        getScene().getStylesheets().addAll(Theme.getTheme().getStylesheets(config().getLauncherFontFamily()));
         getIcons().add(newImage("/assets/img/icon.png"));
         webView.getEngine().setUserDataDirectory(Metadata.HMCL_DIRECTORY.toFile());
         webView.setContextMenuEnabled(false);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FontComboBox.java
@@ -26,7 +26,6 @@ import org.jackhuang.hmcl.util.javafx.BindingMapping;
 import com.jfoenix.controls.JFXComboBox;
 import com.jfoenix.controls.JFXListCell;
 
-import javafx.beans.NamedArg;
 import javafx.beans.binding.Bindings;
 import javafx.scene.text.Font;
 
@@ -34,7 +33,7 @@ public class FontComboBox extends JFXComboBox<String> {
 
     private boolean loaded = false;
 
-    public FontComboBox(@NamedArg(value = "fontSize", defaultValue = "12.0") double fontSize) {
+    public FontComboBox() {
         styleProperty().bind(Bindings.concat("-fx-font-family: \"", valueProperty(), "\""));
 
         setCellFactory(listView -> new JFXListCell<String>() {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -72,7 +72,7 @@ public class PersonalizationPage extends StackPane {
             themeColorPickerContainer.setMinHeight(30);
             themePane.setRight(themeColorPickerContainer);
 
-            ColorPicker picker = new ColorPicker(Color.web(config().getTheme().getColor()));
+            ColorPicker picker = new ColorPicker(Color.web(Theme.getTheme().getColor()));
             picker.getCustomColors().setAll(Theme.SUGGESTED_COLORS);
             picker.setOnAction(e -> {
                 Theme theme = Theme.custom(Theme.getColorDisplayName(picker.getValue()));
@@ -210,7 +210,7 @@ public class PersonalizationPage extends StackPane {
                         () -> Font.font(config().getLauncherFontFamily(), 12),
                         config().launcherFontFamilyProperty()));
                 config().launcherFontFamilyProperty().addListener((a, b, newValue) -> {
-                    Controllers.getScene().getStylesheets().setAll(config().getTheme().getStylesheets(newValue));
+                    Controllers.getScene().getStylesheets().setAll(Theme.getTheme().getStylesheets(newValue));
                 });
 
                 vbox.getChildren().add(lblFontDisplay);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -41,6 +41,7 @@ import org.jackhuang.hmcl.ui.Controllers;
 import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.SVG;
 import org.jackhuang.hmcl.ui.construct.*;
+import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
 
 import java.util.Arrays;
@@ -159,7 +160,7 @@ public class PersonalizationPage extends StackPane {
 
                 Label lblLogFontDisplay = new Label("[23:33:33] [Client Thread/INFO] [WaterPower]: Loaded mod WaterPower.");
                 lblLogFontDisplay.fontProperty().bind(Bindings.createObjectBinding(
-                        () -> Font.font(config().getFontFamily(), config().getFontSize()),
+                        () -> Font.font(Lang.requireNonNullElse(config().getFontFamily(), FXUtils.DEFAULT_MONOSPACE_FONT), config().getFontSize()),
                         config().fontFamilyProperty(), config().fontSizeProperty()));
 
                 fontPane.getChildren().add(lblLogFontDisplay);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -142,7 +142,7 @@ public class PersonalizationPage extends StackPane {
                         HBox hBox = new HBox();
                         hBox.setSpacing(3);
 
-                        FontComboBox cboLogFont = new FontComboBox(12);
+                        FontComboBox cboLogFont = new FontComboBox();
                         cboLogFont.valueProperty().bindBidirectional(config().fontFamilyProperty());
 
                         JFXTextField txtLogFontSize = new JFXTextField();
@@ -192,7 +192,7 @@ public class PersonalizationPage extends StackPane {
                         HBox hBox = new HBox();
                         hBox.setSpacing(8);
 
-                        FontComboBox cboFont = new FontComboBox(12);
+                        FontComboBox cboFont = new FontComboBox();
                         cboFont.valueProperty().bindBidirectional(config().launcherFontFamilyProperty());
 
                         JFXButton clearButton = new JFXButton();

--- a/HMCL/src/main/resources/assets/css/blue.css
+++ b/HMCL/src/main/resources/assets/css/blue.css
@@ -16,9 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 .root {
-    -fx-base-color: #5c6bc0;
+    -fx-base-color: #5C6BC0;
     -fx-base-darker-color: derive(-fx-base-color, -10%);
     -fx-base-check-color: derive(-fx-base-color, 30%);
+    -fx-rippler-color: rgba(92, 107, 192, 0.3);
     -fx-base-rippler-color: rgba(92, 107, 192, 0.3);
+    -fx-base-disabled-text-fill: rgba(256, 256, 256, 0.7);
     -fx-base-text-fill: white;
+
+    -theme-thumb: rgba(92, 107, 192, 0.3);
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Lang.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Lang.java
@@ -34,6 +34,18 @@ public final class Lang {
     private Lang() {
     }
 
+    public static <T> T requireNonNullElse(T value, T defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
+    public static <T> T requireNonNullElseGet(T value, Supplier<? extends T> defaultValue) {
+        return value != null ? value : defaultValue.get();
+    }
+
+    public static <T, U> U requireNonNullElseGet(T value, Function<? super T, ? extends U> mapper, Supplier<? extends U> defaultValue) {
+        return value != null ? mapper.apply(value) : defaultValue.get();
+    }
+
     /**
      * Construct a mutable map by given key-value pairs.
      * @param pairs entries in the new map


### PR DESCRIPTION
* 修复加载 `blue.css` 时启动器崩溃的问题；
* 修复 Windows 下创建的配置文件默认指定日志字体为 `Consolas`，导致在 Linux 下使用同配置文件时未使用等宽字体的问题；
* 修复启动器将 `blue` 主题读取为自定义主题，导致再次保存时将配置文件中 `theme` 被替换为具体颜色编码的问题；
* 不再将默认主题保存进配置文件；
* 默认主题下加载预编译的 `.bss` 文件，优化启动速度。