### PR TITLE
feat: use XDG_DATA_HOME as for Linux working directories

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -17,6 +17,8 @@
  */
 package org.jackhuang.hmcl.util.platform;
 
+import org.jackhuang.hmcl.util.StringUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -274,7 +276,11 @@ public enum OperatingSystem {
         String home = System.getProperty("user.home", ".");
         switch (OperatingSystem.CURRENT_OS) {
             case LINUX:
-                return Paths.get(home, "." + folder);
+                String xdgData = System.getenv("XDG_DATA_HOME");
+                if (StringUtils.isNotBlank(xdgData)) {
+                    return Paths.get(xdgData, folder);
+                }
+                return Paths.get(home, ".local", "share", folder);
             case WINDOWS:
                 String appdata = System.getenv("APPDATA");
                 return Paths.get(appdata == null ? home : appdata, "." + folder);


### PR DESCRIPTION
`~/.{folder} -> $XDG_DATA_HOME/{folder}`

~/.hmcl 里似乎没存什么重要内容，而且也不是配置文件，都是自动下载的 javafx / config.json ，这个文件的内容看起来不常更新，全都把他们放在 XDG_DATA_HOME 应该也没问题。

Disclaimer: XDG_DATA_HOME 不会周期性删除，因此不存在 #1785 提到的问题

Link: https://github.com/huanghongxun/HMCL/pull/1785
Link: https://github.com/huanghongxun/HMCL/issues/849

---

在 https://github.com/huanghongxun/HMCL/issues/849 中，提到了可以配置 HMCL Directory ，但实际上好像并无此选项？