### PR TITLE
fix #1905: fix path splicing

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/JavaVersion.java
@@ -218,7 +218,7 @@ public final class JavaVersion {
     public static final JavaVersion CURRENT_JAVA;
 
     static {
-        Path currentExecutable = getExecutable(Paths.get(System.getProperty("java.home")));
+        Path currentExecutable = getExecutable(Paths.get(System.getProperty("java.home")).toAbsolutePath());
         try {
             currentExecutable = currentExecutable.toRealPath();
         } catch (IOException e) {


### PR DESCRIPTION
理论上后面有一个 `toRealPath()`，不应该出问题的，不知道这个 issue 是啥情况。

`toAbsolutePath()` 能够补全 `:` 后的 `\`，不管是啥原因出的问题应该都能修复了吧。