### PR TITLE
更新查找 HMCL_DIRECTORY 文件夹的逻辑

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -118,7 +118,7 @@ public final class Launcher extends Application {
                     return;
             }
 
-            if (Metadata.HMCL_DIRECTORY.toAbsolutePath().toString().indexOf('=') >= 0) {
+            if (Metadata.HMCL_DIRECTORY.toString().indexOf('=') >= 0) {
                 Main.showWarningAndContinue(i18n("fatal.illegal_char"));
             }
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
@@ -17,10 +17,12 @@
  */
 package org.jackhuang.hmcl;
 
+import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Stores metadata about this application.
@@ -45,7 +47,25 @@ public final class Metadata {
     public static final String BUILD_CHANNEL = JarUtils.getManifestAttribute("Build-Channel", "nightly");
 
     public static final Path MINECRAFT_DIRECTORY = OperatingSystem.getWorkingDirectory("minecraft");
-    public static final Path HMCL_DIRECTORY = OperatingSystem.getWorkingDirectory("hmcl");
+    public static final Path HMCL_DIRECTORY;
+
+    static {
+        String hmclHome = System.getProperty("hmcl.home");
+        if (hmclHome == null) {
+            if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX) {
+                String xdgData = System.getenv("XDG_DATA_HOME");
+                if (StringUtils.isNotBlank(xdgData)) {
+                    HMCL_DIRECTORY = Paths.get(xdgData, "hmcl").toAbsolutePath();
+                } else {
+                    HMCL_DIRECTORY = Paths.get(System.getProperty("user.home", "."), ".local", "share", "hmcl").toAbsolutePath();
+                }
+            } else {
+                HMCL_DIRECTORY = OperatingSystem.getWorkingDirectory("hmcl");
+            }
+        } else {
+            HMCL_DIRECTORY = Paths.get(hmclHome).toAbsolutePath().normalize();
+        }
+    }
 
     public static boolean isStable() {
         return "stable".equals(BUILD_CHANNEL);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/ConfigHolder.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonParseException;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.util.InvocationDispatcher;
 import org.jackhuang.hmcl.util.Lang;
-import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.FileUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
 
@@ -208,28 +207,6 @@ public final class ConfigHolder {
     // Global Config
 
     private static GlobalConfig loadGlobalConfig() throws IOException {
-        // Migrate from old directory
-        if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX && Files.notExists(GLOBAL_CONFIG_PATH)) {
-            Path oldHome;
-            String xdgCache = System.getenv("XDG_CACHE_HOME");
-            if (StringUtils.isNotBlank(xdgCache)) {
-                oldHome = Paths.get(xdgCache, "hmcl");
-            } else {
-                oldHome = Paths.get(System.getProperty("user.home", "."), ".cache", "hmcl");
-            }
-
-            if (Files.exists(oldHome)) {
-                Path oldConfigPath = oldHome.resolve("config.json");
-                if (Files.isRegularFile(oldConfigPath)) {
-                    try {
-                        Files.copy(oldConfigPath, GLOBAL_CONFIG_PATH);
-                    } catch (IOException e) {
-                        LOG.log(Level.WARNING, "Failed to migrate global config", e);
-                    }
-                }
-            }
-        }
-
         if (Files.exists(GLOBAL_CONFIG_PATH)) {
             try {
                 String content = FileUtils.readText(GLOBAL_CONFIG_PATH);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/OperatingSystem.java
@@ -17,8 +17,6 @@
  */
 package org.jackhuang.hmcl.util.platform;
 
-import org.jackhuang.hmcl.util.StringUtils;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -276,18 +274,14 @@ public enum OperatingSystem {
         String home = System.getProperty("user.home", ".");
         switch (OperatingSystem.CURRENT_OS) {
             case LINUX:
-                String xdgData = System.getenv("XDG_DATA_HOME");
-                if (StringUtils.isNotBlank(xdgData)) {
-                    return Paths.get(xdgData, folder);
-                }
-                return Paths.get(home, ".local", "share", folder);
+                return Paths.get(home, "." + folder).toAbsolutePath();
             case WINDOWS:
                 String appdata = System.getenv("APPDATA");
-                return Paths.get(appdata == null ? home : appdata, "." + folder);
+                return Paths.get(appdata == null ? home : appdata, "." + folder).toAbsolutePath();
             case OSX:
-                return Paths.get(home, "Library", "Application Support", folder);
+                return Paths.get(home, "Library", "Application Support", folder).toAbsolutePath();
             default:
-                return Paths.get(home, folder);
+                return Paths.get(home, folder).toAbsolutePath();
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,16 @@ Simply execute the following command in project root directory:
 Make sure you have Java installed with JavaFX 8 at least. Liberica Full JDK 8 or later is recommended.
 
 ## JVM Options (for debugging)
-| Parameter                                    | Description                                                  |
-| -------------------------------------------- | ------------------------------------------------------------ |
-| `-Dhmcl.self_integrity_check.disable=true`   | Bypass the self integrity check when checking for update.    |
+| Parameter                                    | Description                                                                                                                       |
+|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `-Dhmcl.home=<path>`                         | Override HMCL directory.                                                                                                          |
+| `-Dhmcl.self_integrity_check.disable=true`   | Bypass the self integrity check when checking for update.                                                                         |
 | `-Dhmcl.bmclapi.override=<version>`          | Override API Root of BMCLAPI download provider, defaults to `https://bmclapi2.bangbang93.com`. e.g. `https://download.mcbbs.net`. |
-| `-Dhmcl.font.override=<font family>`         | Override font family.                                        |
-| `-Dhmcl.version.override=<version>`          | Override the version number.                                 |
-| `-Dhmcl.update_source.override=<url>`        | Override the update source.                                  |
-| `-Dhmcl.authlibinjector.location=<path>`     | Use specified authlib-injector (instead of downloading one). |
-| `-Dhmcl.openjfx.repo=<maven repository url>` | Add custom Maven repository for download OpenJFX.            |
-| `-Dhmcl.native.encoding=<encoding>`          | Override the native encoding.                                |
-| `-Dhmcl.microsoft.auth.id=<App ID>`          | Override Microsoft OAuth App ID.                             |
-| `-Dhmcl.microsoft.auth.secret=<App Secret>`  | Override Microsoft OAuth App secret.                         |
+| `-Dhmcl.font.override=<font family>`         | Override font family.                                                                                                             |
+| `-Dhmcl.version.override=<version>`          | Override the version number.                                                                                                      |
+| `-Dhmcl.update_source.override=<url>`        | Override the update source.                                                                                                       |
+| `-Dhmcl.authlibinjector.location=<path>`     | Use specified authlib-injector (instead of downloading one).                                                                      |
+| `-Dhmcl.openjfx.repo=<maven repository url>` | Add custom Maven repository for download OpenJFX.                                                                                 |
+| `-Dhmcl.native.encoding=<encoding>`          | Override the native encoding.                                                                                                     |
+| `-Dhmcl.microsoft.auth.id=<App ID>`          | Override Microsoft OAuth App ID.                                                                                                  |
+| `-Dhmcl.microsoft.auth.secret=<App Secret>`  | Override Microsoft OAuth App secret.                                                                                              |

--- a/README_cn.md
+++ b/README_cn.md
@@ -48,15 +48,16 @@ HMCL 有着强大的跨平台能力。它不仅支持 Windows、Linux、macOS �
 请确保您至少安装了含有 JavaFX 8 的 Java. 建议使用 Liberica Full JDK 8 或更高版本.
 
 ## JVM 选项 (用于调试)
-| 参数                                         | 简介                                        |
-| -------------------------------------------- | ------------------------------------------- |
-| `-Dhmcl.self_integrity_check.disable=true`   | 检查更新时绕过本体完整性检查.               |
+| 参数                                           | 简介                                                                                              |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `-Dhmcl.home=<path>`                         | 覆盖 HMCL 数据文件夹.                                                                                  |
+| `-Dhmcl.self_integrity_check.disable=true`   | 检查更新时绕过本体完整性检查.                                                                                 |
 | `-Dhmcl.bmclapi.override=<version>`          | 覆盖 BMCLAPI 的 API Root, 默认值为 `https://bmclapi2.bangbang93.com`. 例如 `https://download.mcbbs.net`. |
-| `-Dhmcl.font.override=<font family>`         | 覆盖字族.                                   |
-| `-Dhmcl.version.override=<version>`          | 覆盖版本号.                                 |
-| `-Dhmcl.update_source.override=<url>`        | 覆盖更新源.                                 |
-| `-Dhmcl.authlibinjector.location=<path>`     | 使用指定的 authlib-injector (而非下载一个). |
-| `-Dhmcl.openjfx.repo=<maven repository url>` | 添加用于下载 OpenJFX 的自定义 Maven 仓库    |
-| `-Dhmcl.native.encoding=<encoding>`          | 覆盖原生编码.                               |
-| `-Dhmcl.microsoft.auth.id=<App ID>`          | 覆盖 Microsoft OAuth App ID.                |
-| `-Dhmcl.microsoft.auth.secret=<App Secret>`  | 覆盖 Microsoft OAuth App 密钥.              |
+| `-Dhmcl.font.override=<font family>`         | 覆盖字族.                                                                                           |
+| `-Dhmcl.version.override=<version>`          | 覆盖版本号.                                                                                          |
+| `-Dhmcl.update_source.override=<url>`        | 覆盖更新源.                                                                                          |
+| `-Dhmcl.authlibinjector.location=<path>`     | 使用指定的 authlib-injector (而非下载一个).                                                                |
+| `-Dhmcl.openjfx.repo=<maven repository url>` | 添加用于下载 OpenJFX 的自定义 Maven 仓库                                                                    |
+| `-Dhmcl.native.encoding=<encoding>`          | 覆盖原生编码.                                                                                         |
+| `-Dhmcl.microsoft.auth.id=<App ID>`          | 覆盖 Microsoft OAuth App ID.                                                                      |
+| `-Dhmcl.microsoft.auth.secret=<App Secret>`  | 覆盖 Microsoft OAuth App 密钥.                                                                      |


### PR DESCRIPTION
* 修复被 #1948 造成的无法找到用户 Minecraft 文件夹的问题；
* 新添加 JVM 选项 `hmcl.home`，允许用户自行指定 HMCL_DIRECTORY 。