### PR TITLE
Add icon for qq channel

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
@@ -110,7 +110,7 @@ public class AboutPage extends StackPane {
             users.setExternalLink("https://hmcl.huangyuhui.net/api/redirect/sponsor");
 
             IconedTwoLineListItem qq = new IconedTwoLineListItem();
-//            qq.setImage(new Image("/assets/img/qq.png", 32, 32, false, true));
+            qq.setImage(new Image("/assets/img/icon.png", 32, 32, false, true));
             qq.setTitle(i18n("about.community.qqchannel"));
             qq.setSubtitle(i18n("about.community.qqchannel.statement"));
             qq.setExternalLink("https://pd.qq.com/s/qor74cm6");


### PR DESCRIPTION
不添加 logo 的话，排版太丑了

![image](https://user-images.githubusercontent.com/20694662/210057449-5e7cae2c-ea6c-48b3-aebb-c63a161a3368.png)

在弄明白图标版权问题前，先把 HMCL Logo 放那吧。