### PR TITLE
feat(util): utilize the XDG Base Directory to reduce fragmentation

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
@@ -17,9 +17,9 @@
  */
 package org.jackhuang.hmcl;
 
-import org.jackhuang.hmcl.util.StringUtils;
 import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
+import org.jackhuang.hmcl.util.platform.XDGBaseDirectory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,12 +53,7 @@ public final class Metadata {
         String hmclHome = System.getProperty("hmcl.home");
         if (hmclHome == null) {
             if (OperatingSystem.CURRENT_OS == OperatingSystem.LINUX) {
-                String xdgData = System.getenv("XDG_DATA_HOME");
-                if (StringUtils.isNotBlank(xdgData)) {
-                    HMCL_DIRECTORY = Paths.get(xdgData, "hmcl").toAbsolutePath();
-                } else {
-                    HMCL_DIRECTORY = Paths.get(System.getProperty("user.home", "."), ".local", "share", "hmcl").toAbsolutePath();
-                }
+                HMCL_DIRECTORY = Paths.get(XDGBaseDirectory.getDataHome(), "hmcl");
             } else {
                 HMCL_DIRECTORY = OperatingSystem.getWorkingDirectory("hmcl");
             }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
@@ -1,4 +1,3 @@
-
 /*
  * Hello Minecraft! Launcher
  * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
@@ -25,8 +24,6 @@ import java.util.Map;
  * Utilize the Base Directory Specification
  * For default values and the specification, please refer to the freedesktop XDG
  * Base Directory Specification.
- *
- * @see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
  */
 public class XDGBaseDirectory {
     private static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
@@ -35,6 +32,10 @@ public class XDGBaseDirectory {
     private static final String XDG_DATA_HOME = "XDG_DATA_HOME";
     private static final String XDG_DATA_DIRS = "XDG_DATA_DIRS";
     private static final String XDG_RUNTIME_DIR = "XDG_RUNTIME_DIR";
+
+    private XDGBaseDirectory() {}
+
+
 
     private static Map<String, String> environment = System.getenv();
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * For default values and the specification, please refer to the freedesktop XDG
  * Base Directory Specification.
  */
-public class XDGBaseDirectory {
+public final class XDGBaseDirectory {
     private static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
     private static final String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
     private static final String XDG_CONFIG_DIRS = "XDG_CONFIG_DIRS";

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/platform/XDGBaseDirectory.java
@@ -1,0 +1,96 @@
+
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.util.platform;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Utilize the Base Directory Specification
+ * For default values and the specification, please refer to the freedesktop XDG
+ * Base Directory Specification.
+ *
+ * @see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+public class XDGBaseDirectory {
+    private static final String XDG_CACHE_HOME = "XDG_CACHE_HOME";
+    private static final String XDG_CONFIG_HOME = "XDG_CONFIG_HOME";
+    private static final String XDG_CONFIG_DIRS = "XDG_CONFIG_DIRS";
+    private static final String XDG_DATA_HOME = "XDG_DATA_HOME";
+    private static final String XDG_DATA_DIRS = "XDG_DATA_DIRS";
+    private static final String XDG_RUNTIME_DIR = "XDG_RUNTIME_DIR";
+
+    private static Map<String, String> environment = System.getenv();
+
+    public static String getCacheHome() {
+        String value = environment.get(XDG_CACHE_HOME);
+        if (value == null || value.trim().length() == 0) {
+            String XDG_CACHE_HOME_DEFAULT = environment.get("HOME") + File.separator + ".cache";
+            value = XDG_CACHE_HOME_DEFAULT;
+        }
+        return value;
+    }
+
+    public static String getConfigHome() {
+        String value = environment.get(XDG_CONFIG_HOME);
+        if (value == null || value.trim().length() == 0) {
+            String XDG_CONFIG_HOME_DEFAULT = environment.get("HOME") + File.separator + ".config";
+            value = XDG_CONFIG_HOME_DEFAULT;
+        }
+        return value;
+    }
+
+    public static String getConfigDirs() {
+        String value = environment.get(XDG_CONFIG_DIRS);
+        if (value == null || value.trim().length() == 0) {
+            String XDG_CONFIG_DIRS_DEFAULT = File.separator + "etc" + File.separator + "xdg";
+            value = XDG_CONFIG_DIRS_DEFAULT;
+        }
+        return value;
+    }
+
+    public static String getDataHome() {
+        String value = environment.get(XDG_DATA_HOME);
+        if (value == null || value.trim().length() == 0) {
+            String XDG_DATA_HOME_DEFAULT = environment.get("HOME") +
+                    File.separator + ".local" + File.separator + "share";
+            value = XDG_DATA_HOME_DEFAULT;
+        }
+        return value;
+    }
+
+    public static String getDataDirs() {
+        String value = environment.get(XDG_DATA_DIRS);
+        if (value == null || value.trim().length() == 0) {
+            String XDG_DATA_DIRS_DEFAULT = File.separator + "usr" + File.separator + "local" + File.separator + "share"
+                    + File.separator;
+            XDG_DATA_DIRS_DEFAULT = XDG_DATA_DIRS_DEFAULT + File.pathSeparator;
+            XDG_DATA_DIRS_DEFAULT = XDG_DATA_DIRS_DEFAULT + File.separator + "usr" + File.separator + "share"
+                    + File.separator;
+            value = XDG_DATA_DIRS_DEFAULT;
+        }
+        return value;
+    }
+
+    public static String getRuntimeDir() {
+        String value = environment.get(XDG_RUNTIME_DIR);
+        return value;
+    }
+
+}


### PR DESCRIPTION
Implement the XDG Base Directory Specification according to freedesktop.org. This should reduce fragmentation of many uses of these directories.

Link: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html