### PR TITLE
Delete javaw.exe extension filter

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -576,7 +576,7 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
 
         javaItem.setSelectedData(null);
         if (OperatingSystem.CURRENT_OS == OperatingSystem.WINDOWS)
-            javaCustomOption.getExtensionFilters().add(new FileChooser.ExtensionFilter("Java", "java.exe", "javaw.exe"));
+            javaCustomOption.getExtensionFilters().add(new FileChooser.ExtensionFilter("Java", "java.exe"));
 
         enableSpecificSettings.addListener((a, b, newValue) -> {
             if (versionId == null) return;


### PR DESCRIPTION
允许用户选择 `javaw.exe` 没有什么意义，反而因为有两个选择可能造成混乱。