### PR TITLE
不再使用 Pack200 压缩构建

### DIFF
--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -1,31 +1,11 @@
+import java.net.URI
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.security.KeyFactory
 import java.security.MessageDigest
 import java.security.Signature
 import java.security.spec.PKCS8EncodedKeySpec
-import java.util.jar.JarFile
-import java.util.jar.JarOutputStream
 import java.util.zip.ZipFile
-import java.util.zip.GZIPOutputStream
-import java.io.ByteArrayOutputStream
-import java.io.ByteArrayInputStream
-import java.net.URI
-
-import org.glavo.pack200.Pack200
-import org.tukaani.xz.LZMA2Options
-import org.tukaani.xz.XZOutputStream
-
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        maven(url = "https://jitpack.io")
-    }
-    dependencies {
-        classpath("org.tukaani:xz:1.8")
-        classpath("org.glavo:pack200:0.3.0")
-    }
-}
 
 plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
@@ -92,21 +72,6 @@ fun attachSignature(jar: File) {
     }
 }
 
-val packer = Pack200.newPacker().apply {
-    properties()["pack.effort"] = "9"
-}
-
-val unpacker = Pack200.newUnpacker()
-
-// Pack200 does not guarantee that unpacked .class file is bit-wise same as the .class file before packing
-// because of shrinking. So we should pack .class files and unpack it to make sure that after unpacking
-// .class files remain the same.
-fun repack(file: File) {
-    val packed = ByteArrayOutputStream()
-    JarFile(file).use { packer.pack(it, packed) }
-    JarOutputStream(file.outputStream()).use { unpacker.unpack(ByteArrayInputStream(packed.toByteArray()), it) }
-}
-
 val java11 = sourceSets.create("java11") {
     java {
         srcDir("src/main/java11")
@@ -168,7 +133,6 @@ tasks.getByName<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("sha
     }
 
     doLast {
-        repack(jarPath) // see repack()
         attachSignature(jarPath)
         createChecksum(jarPath)
     }
@@ -215,46 +179,7 @@ tasks.processResources {
     dependsOn(rootProject.tasks["generateOpenJFXDependencies"])
 }
 
-val packFile = File(jarPath.parentFile, jarPath.nameWithoutExtension + ".pack")
-
-val makePack = tasks.create("makePack") {
-    dependsOn(tasks.jar)
-
-    doLast {
-        packFile.outputStream().use { out ->
-            JarFile(jarPath).use { jarFile -> packer.pack(jarFile, out) }
-        }
-        createChecksum(packFile)
-    }
-}
-
-val makePackXz = tasks.create("makePackXz") {
-    dependsOn(makePack)
-
-    val packXz = File(packFile.parentFile, packFile.name + ".xz")
-
-    doLast {
-        // Our CI server does not have enough memory space to compress file at highest level.
-        XZOutputStream(packXz.outputStream(), LZMA2Options(5))
-            .use { it.write(packFile.readBytes()) }
-        createChecksum(packXz)
-    }
-}
-
-val makePackGz = tasks.create("makePackGz") {
-    dependsOn(makePack)
-
-    val packGz = File(packFile.parentFile, packFile.name + ".gz")
-
-    doLast {
-        GZIPOutputStream(packGz.outputStream()).use { it.write(packFile.readBytes()) }
-        createChecksum(packGz)
-    }
-}
-
 val makeExecutables = tasks.create("makeExecutables") {
-    dependsOn(makePack)
-
     doLast {
         createExecutable("exe", "src/main/resources/assets/HMCLauncher.exe")
         createExecutable("sh", "src/main/resources/assets/HMCLauncher.sh")
@@ -262,7 +187,7 @@ val makeExecutables = tasks.create("makeExecutables") {
 }
 
 tasks.build {
-    dependsOn(makePackXz, makePackGz, makeExecutables)
+    dependsOn(makeExecutables)
 }
 
 tasks.create<JavaExec>("run") {


### PR DESCRIPTION
本 PR 提议放弃通过 Pack200 压缩 HMCL。

理由：

* 由于新版 Minecraft 开始使用 Java 17，高版本 Java 的使用率提高，而 Java 14 中已经移除了 Pack200 支持，因此 Pack200 的使用率越来越低，意义逐渐减小；
* 现在 HMCL 服务器仅需要提供更新内容的 JSON 元数据，放弃支持 Pack200 能够让 JSON 元数据减少约 33% 的体积，降低 HMCL 服务器的负载；
* 不分发 `.pack` 文件后可以省略构建过程中的 `repack` 操作，提高构建效率；
* HMCL 的 `.pack.xz` 文件有时候会触发 Sonatype 的 BUG，导致新版本无法正常发布（Glavo/HMCL-Update/issues/2），阻塞新版本发布流程，此问题至今尚未完全解决。

这些问题中影响最大的是 Sonatype 上传的 BUG，一旦触发就会严重影响新版本发布进程，我不得不反复与 Sonatype 沟通，由 Sonatype 工作人员手动给我放宽限制才能正常发布新版本。

因此，我已经在 HMCL-Update 中放弃上传其他格式的分发，仅上传 `.jar` 文件，避免不必要的麻烦。

在 HMCL-Update 放弃 `.pack` 与 `.pack.xz` 后，HMCL 使用 Pack200 压缩的意义不再存在，所以我希望 HMCL 直接放弃使用 Pack200 压缩。

由于 HMCL 会检查更新 JSON 中是否包含 `packxz` 值，不存在时 HMCL 会自动选择下载 jar，所以不会造成问题。

 `org.jackhuang.hmcl.upgrade` 中对 Pack200 的可选支持继续保留，如果以后因为某种原因需要重新加入 Pack200，HMCL 依然会自动尝试下载 `.pack.xz` 文件。