### PR TITLE
fix memory leak

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/Texture.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/offline/Texture.java
@@ -112,7 +112,10 @@ public class Texture {
 
     public static Texture loadTexture(InputStream in) throws IOException {
         if (in == null) return null;
-        BufferedImage img = ImageIO.read(in);
+        BufferedImage img;
+        try (InputStream is = in) {
+            img = ImageIO.read(is);
+        }
         if (img == null) {
             throw new IIOException("No image found");
         }


### PR DESCRIPTION
`ImageIO.read` 不会关闭接受的 `InputStream`，因此导致内存泄漏。