### PR TITLE
将 ImageIO 迁移至 JavaFX Image

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListItem.java
@@ -25,6 +25,7 @@ import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.Skin;
+import javafx.scene.image.Image;
 import javafx.stage.FileChooser;
 import org.jackhuang.hmcl.auth.Account;
 import org.jackhuang.hmcl.auth.AuthenticationException;
@@ -47,9 +48,8 @@ import org.jackhuang.hmcl.util.skin.InvalidSkinException;
 import org.jackhuang.hmcl.util.skin.NormalizedSkin;
 import org.jetbrains.annotations.Nullable;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
@@ -167,14 +167,14 @@ public class AccountListItem extends RadioButton {
 
         return refreshAsync()
                 .thenRunAsync(() -> {
-                    BufferedImage skinImg;
-                    try {
-                        skinImg = ImageIO.read(selectedFile);
+                    Image skinImg;
+                    try (FileInputStream input = new FileInputStream(selectedFile)) {
+                        skinImg = new Image(input);
                     } catch (IOException e) {
                         throw new InvalidSkinException("Failed to read skin image", e);
                     }
-                    if (skinImg == null) {
-                        throw new InvalidSkinException("Failed to read skin image");
+                    if (skinImg.isError()) {
+                        throw new InvalidSkinException("Failed to read skin image", skinImg.getException());
                     }
                     NormalizedSkin skin = new NormalizedSkin(skinImg);
                     String model = skin.isSlim() ? "slim" : "";

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/OfflineAccountSkinPane.java
@@ -141,9 +141,9 @@ public class OfflineAccountSkinPane extends StackPane {
                                 return;
                             }
                             canvas.updateSkin(
-                                    result.getSkin() != null ? new Image(result.getSkin().getInputStream()) : getDefaultTexture(),
+                                    result.getSkin() != null ? result.getSkin().getImage() : getDefaultTexture(),
                                     result.getModel() == TextureModel.ALEX,
-                                    result.getCape() != null ? new Image(result.getCape().getInputStream()) : null);
+                                    result.getCape() != null ? result.getCape().getImage() : null);
                         }
                     }).start();
         }, skinItem.selectedDataProperty(), cslApiField.textProperty(), skinSelector.valueProperty(), capeSelector.valueProperty());

--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    api("org.glavo:simple-png:0.1.1")
     api("com.google.code.gson:gson:2.8.1")
     api("com.moandjiezana.toml:toml4j:0.7.2")
     api("org.tukaani:xz:1.8")

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
@@ -2,6 +2,7 @@ package org.jackhuang.hmcl.util.skin;
 
 import javafx.scene.image.Image;
 import org.jackhuang.hmcl.JavaFXLauncher;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
@@ -15,6 +16,7 @@ public class NormalizedSkinTest {
     }
 
     @Test
+    @Disabled("Cannot run in headless mode")
     public void testIsSlim() throws Exception {
         JavaFXLauncher.start();
         assertFalse(getSkin("steve").isSlim());

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
@@ -1,21 +1,22 @@
 package org.jackhuang.hmcl.util.skin;
 
+import javafx.scene.image.Image;
+import org.jackhuang.hmcl.JavaFXLauncher;
 import org.junit.jupiter.api.Test;
 
-import javax.imageio.ImageIO;
-import java.io.File;
-import java.io.IOException;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class NormalizedSkinTest {
-    private static NormalizedSkin getSkin(String name) throws IOException, InvalidSkinException {
-        File path = new File("../HMCL/src/main/resources/assets/img/skin/" + name + ".png");
-        return new NormalizedSkin(ImageIO.read(path));
+    private static NormalizedSkin getSkin(String name) throws InvalidSkinException {
+        String path = Paths.get("../HMCL/src/main/resources/assets/img/skin/" + name + ".png").normalize().toAbsolutePath().toUri().toString();
+        return new NormalizedSkin(new Image(path));
     }
 
     @Test
     public void testIsSlim() throws Exception {
+        JavaFXLauncher.start();
         assertFalse(getSkin("steve").isSlim());
         assertTrue(getSkin("alex").isSlim());
         assertTrue(getSkin("noor").isSlim());

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/skin/NormalizedSkinTest.java
@@ -1,0 +1,29 @@
+package org.jackhuang.hmcl.util.skin;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NormalizedSkinTest {
+    private static NormalizedSkin getSkin(String name) throws IOException, InvalidSkinException {
+        File path = new File("../HMCL/src/main/resources/assets/img/skin/" + name + ".png");
+        return new NormalizedSkin(ImageIO.read(path));
+    }
+
+    @Test
+    public void testIsSlim() throws Exception {
+        assertFalse(getSkin("steve").isSlim());
+        assertTrue(getSkin("alex").isSlim());
+        assertTrue(getSkin("noor").isSlim());
+        assertFalse(getSkin("sunny").isSlim());
+        assertFalse(getSkin("ari").isSlim());
+        assertFalse(getSkin("zuri").isSlim());
+        assertTrue(getSkin("makena").isSlim());
+        assertFalse(getSkin("kai").isSlim());
+        assertTrue(getSkin("efe").isSlim());
+    }
+}


### PR DESCRIPTION
已经完成，但是需要更多测试以确保所有情况下的正确性。

现在 HMCL 只剩下最后一点对 AWT/Swing 的依赖，移除它们很轻松。不依赖于 AWT/Swing 有助于将 HMCL 使用 native-image AOT 化，另外消除一些不必要的多次读取图片。

由于 HMCL 需要将图片转换为 PNG，而 JavaFX 并不支持此操作，我实现了一个非常轻便的 PNG 库 [SimplePNG](https://github.com/Glavo/SimplePNG) 来完成此操作。