### PR TITLE
使用 Locale.forLanguageTag 替代构造器调用

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/util/i18n/Locales.java
@@ -58,12 +58,12 @@ public final class Locales {
     /**
      * Spanish
      */
-    public static final SupportedLocale ES = new SupportedLocale(new Locale("es"));
+    public static final SupportedLocale ES = new SupportedLocale(Locale.forLanguageTag("es"));
 
     /**
      * Russian
      */
-    public static final SupportedLocale RU = new SupportedLocale(new Locale("ru"));
+    public static final SupportedLocale RU = new SupportedLocale(Locale.forLanguageTag("ru"));
 
     /**
      * Japanese


### PR DESCRIPTION
Java 19 中，Locale 的构造器已经被弃用。