### PR TITLE
将日志窗口的最大输出值调整至 10000

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/LogWindow.java
@@ -163,7 +163,7 @@ public final class LogWindow extends Stage {
             getStyleClass().add("log-window");
 
             boolean flag = false;
-            cboLines.getItems().setAll("500", "2000", "5000");
+            cboLines.getItems().setAll("10000", "5000", "2000", "500");
             for (String i : cboLines.getItems())
                 if (Integer.toString(config().getLogLines()).equals(i)) {
                     cboLines.getSelectionModel().select(i);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/64117916/216601785-ec319c85-6c0a-4777-a4e8-ee3a493611ff.png)
这样日志崩溃窗口的导出日志里面的 minecraft.log 就可以有 10000 行