### PR TITLE
从 JAR 中排除 JavaFX

### DIFF
--- a/javafx.gradle.kts
+++ b/javafx.gradle.kts
@@ -76,7 +76,7 @@ if (!jfxInClasspath && JavaVersion.current() >= JavaVersion.VERSION_11) {
             val classifier = platform.classifier
             rootProject.subprojects {
                 for (module in jfxModules) {
-                    dependencies.add("implementation", "$groupId:javafx-$module:$version:$classifier")
+                    dependencies.add("compileOnly", "$groupId:javafx-$module:$version:$classifier")
                     dependencies.add("testImplementation", "$groupId:javafx-$module:$version:$classifier")
                 }
             }


### PR DESCRIPTION
避免在没有 JavaFX 的 JDK 上构建 HMCL 时将 JavaFX 打包进 HMCL 中。