### PR TITLE
fix #1917

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileSelector.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/construct/FileSelector.java
@@ -29,6 +29,7 @@ import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import org.jackhuang.hmcl.setting.Theme;
 import org.jackhuang.hmcl.ui.Controllers;
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.SVG;
 
 import java.io.File;
@@ -77,11 +78,11 @@ public class FileSelector extends HBox {
 
     public FileSelector() {
         JFXTextField customField = new JFXTextField();
-        customField.textProperty().bindBidirectional(valueProperty());
+        FXUtils.bindString(customField, valueProperty());
 
         JFXButton selectButton = new JFXButton();
         selectButton.setGraphic(SVG.folderOpen(Theme.blackFillBinding(), 15, 15));
-        selectButton.setOnMouseClicked(e -> {
+        selectButton.setOnAction(e -> {
             if (directory) {
                 DirectoryChooser chooser = new DirectoryChooser();
                 chooser.setTitle(chooserTitle);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -43,6 +43,7 @@ import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
 import org.jackhuang.hmcl.util.Lang;
 import org.jackhuang.hmcl.util.Pair;
 import org.jackhuang.hmcl.util.javafx.BindingMapping;
+import org.jackhuang.hmcl.util.javafx.SafeStringConverter;
 import org.jackhuang.hmcl.util.platform.Architecture;
 import org.jackhuang.hmcl.util.platform.JavaVersion;
 import org.jackhuang.hmcl.util.platform.OperatingSystem;
@@ -256,7 +257,7 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
                     JFXTextField txtMaxMemory = new JFXTextField();
                     FXUtils.setLimitWidth(txtMaxMemory, 60);
                     FXUtils.setValidateWhileTextChanged(txtMaxMemory, true);
-                    FXUtils.bindInt(txtMaxMemory, maxMemory);
+                    txtMaxMemory.textProperty().bindBidirectional(maxMemory, SafeStringConverter.fromInteger());
                     txtMaxMemory.setValidators(new NumberValidator(i18n("input.number"), false));
 
                     lowerBoundPane.getChildren().setAll(label, slider, txtMaxMemory, new Label("MB"));


### PR DESCRIPTION
* 使 `FileSelector` 中的文本框延迟提交变化；
* 修复 #1917；
* 修复 `txtMaxMemory` 未与 `maxMemory` 解绑带来的内存泄漏。