### PR TITLE
适配 GTK 3

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Main.java
@@ -58,8 +58,6 @@ public final class Main {
         System.setProperty("java.net.useSystemProxies", "true");
         System.setProperty("javafx.autoproxy.disable", "true");
         System.getProperties().putIfAbsent("http.agent", "HMCL/" + Metadata.VERSION);
-        // Fix title bar not displaying in GTK systems
-        System.getProperties().putIfAbsent("jdk.gtk.version", "2");
 
         checkDirectoryPath();
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/FXUtils.java
@@ -275,7 +275,7 @@ public final class FXUtils {
     }
 
     public static void smoothScrolling(ScrollPane scrollPane) {
-        JFXScrollPane.smoothScrolling(scrollPane);
+        ScrollUtils.addSmoothScrolling(scrollPane);
     }
 
     public static void installFastTooltip(Node node, Tooltip tooltip) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ListPageSkin.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui;
 
 import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -56,7 +55,7 @@ public class ListPageSkin extends SkinBase<ListPage<?>> {
                 Bindings.bindContent(list.getChildren(), skinnable.itemsProperty());
 
                 scrollPane.setContent(content);
-                JFXScrollPane.smoothScrolling(scrollPane);
+                FXUtils.smoothScrolling(scrollPane);
             }
             
             VBox vBox = new VBox();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ScrollUtils.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ScrollUtils.java
@@ -1,0 +1,215 @@
+// Copy from https://github.com/palexdev/MaterialFX/blob/c8038ce2090f5cddf923a19d79cc601db86a4d17/materialfx/src/main/java/io/github/palexdev/materialfx/utils/ScrollUtils.java
+
+/*
+ * Copyright (C) 2022 Parisi Alessandro
+ * This file is part of MaterialFX (https://github.com/palexdev/MaterialFX).
+ *
+ * MaterialFX is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MaterialFX is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MaterialFX.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.jackhuang.hmcl.ui;
+
+import javafx.animation.Animation;
+import javafx.animation.Animation.Status;
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.event.EventHandler;
+import javafx.geometry.Bounds;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
+import javafx.util.Duration;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * Utility class for ScrollPanes.
+ */
+final class ScrollUtils {
+
+    public enum ScrollDirection {
+        UP(-1), RIGHT(-1), DOWN(1), LEFT(1);
+
+        final int intDirection;
+
+        ScrollDirection(int intDirection) {
+            this.intDirection = intDirection;
+        }
+
+        public int intDirection() {
+            return intDirection;
+        }
+    }
+
+    private ScrollUtils() {
+    }
+
+    /**
+     * Determines if the given ScrollEvent comes from a trackpad.
+     * <p></p>
+     * Although this method works in most cases, it is not very accurate.
+     * Since in JavaFX there's no way to tell if a ScrollEvent comes from a trackpad or a mouse
+     * we use this trick: I noticed that a mouse scroll has a delta of 32 (don't know if it changes depending on the device or OS)
+     * and trackpad scrolls have a way smaller delta. So depending on the scroll direction we check if the delta is lesser than 10
+     * (trackpad event) or greater(mouse event).
+     *
+     * @see ScrollEvent#getDeltaX()
+     * @see ScrollEvent#getDeltaY()
+     */
+    public static boolean isTrackPad(ScrollEvent event, ScrollDirection scrollDirection) {
+        switch (scrollDirection) {
+            case UP:
+            case DOWN:
+                return Math.abs(event.getDeltaY()) < 10;
+            case LEFT:
+            case RIGHT:
+                return Math.abs(event.getDeltaX()) < 10;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Determines the scroll direction of the given ScrollEvent.
+     * <p></p>
+     * Although this method works fine, it is not very accurate.
+     * In JavaFX there's no concept of scroll direction, if you try to scroll with a trackpad
+     * you'll notice that you can scroll in both directions at the same time, both deltaX and deltaY won't be 0.
+     * <p></p>
+     * For this method to work we assume that this behavior is not possible.
+     * <p></p>
+     * If deltaY is 0 we return LEFT or RIGHT depending on deltaX (respectively if lesser or greater than 0).
+     * <p>
+     * Else we return DOWN or UP depending on deltaY (respectively if lesser or greater than 0).
+     *
+     * @see ScrollEvent#getDeltaX()
+     * @see ScrollEvent#getDeltaY()
+     */
+    public static ScrollDirection determineScrollDirection(ScrollEvent event) {
+        double deltaX = event.getDeltaX();
+        double deltaY = event.getDeltaY();
+
+        if (deltaY == 0.0) {
+            return deltaX < 0 ? ScrollDirection.LEFT : ScrollDirection.RIGHT;
+        } else {
+            return deltaY < 0 ? ScrollDirection.DOWN : ScrollDirection.UP;
+        }
+    }
+
+    //================================================================================
+    // ScrollPanes
+    //================================================================================
+
+    /**
+     * Adds a smooth scrolling effect to the given scroll pane,
+     * calls {@link #addSmoothScrolling(ScrollPane, double)} with a
+     * default speed value of 1.
+     */
+    public static void addSmoothScrolling(ScrollPane scrollPane) {
+        addSmoothScrolling(scrollPane, 1);
+    }
+
+    /**
+     * Adds a smooth scrolling effect to the given scroll pane with the given scroll speed.
+     * Calls {@link #addSmoothScrolling(ScrollPane, double, double)}
+     * with a default trackPadAdjustment of 7.
+     */
+    public static void addSmoothScrolling(ScrollPane scrollPane, double speed) {
+        addSmoothScrolling(scrollPane, speed, 7);
+    }
+
+    /**
+     * Adds a smooth scrolling effect to the given scroll pane with the given
+     * scroll speed and the given trackPadAdjustment.
+     * <p></p>
+     * The trackPadAdjustment is a value used to slow down the scrolling if a trackpad is used.
+     * This is kind of a workaround and it's not perfect, but at least it's way better than before.
+     * The default value is 7, tested up to 10, further values can cause scrolling misbehavior.
+     */
+    public static void addSmoothScrolling(ScrollPane scrollPane, double speed, double trackPadAdjustment) {
+        smoothScroll(scrollPane, speed, trackPadAdjustment);
+    }
+
+    private static void smoothScroll(ScrollPane scrollPane, double speed, double trackPadAdjustment) {
+        final double[] frictions = {0.99, 0.1, 0.05, 0.04, 0.03, 0.02, 0.01, 0.04, 0.01, 0.008, 0.008, 0.008, 0.008, 0.0006, 0.0005, 0.00003, 0.00001};
+        final double[] derivatives = new double[frictions.length];
+        AtomicReference<Double> atomicSpeed = new AtomicReference<>(speed);
+
+        Timeline timeline = new Timeline();
+        AtomicReference<ScrollDirection> scrollDirection = new AtomicReference<>();
+        final EventHandler<MouseEvent> mouseHandler = event -> timeline.stop();
+        final EventHandler<ScrollEvent> scrollHandler = event -> {
+            if (event.getEventType() == ScrollEvent.SCROLL) {
+                scrollDirection.set(determineScrollDirection(event));
+                if (isTrackPad(event, scrollDirection.get())) {
+                    atomicSpeed.set(speed / trackPadAdjustment);
+                } else {
+                    atomicSpeed.set(speed);
+                }
+                derivatives[0] += scrollDirection.get().intDirection * atomicSpeed.get();
+                if (timeline.getStatus() == Status.STOPPED) {
+                    timeline.play();
+                }
+                event.consume();
+            }
+        };
+        if (scrollPane.getContent().getParent() != null) {
+            scrollPane.getContent().getParent().addEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+            scrollPane.getContent().getParent().addEventHandler(ScrollEvent.ANY, scrollHandler);
+        }
+        scrollPane.getContent().parentProperty().addListener((observable, oldValue, newValue) -> {
+            if (oldValue != null) {
+                oldValue.removeEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+                oldValue.removeEventHandler(ScrollEvent.ANY, scrollHandler);
+            }
+            if (newValue != null) {
+                newValue.addEventHandler(MouseEvent.MOUSE_PRESSED, mouseHandler);
+                newValue.addEventHandler(ScrollEvent.ANY, scrollHandler);
+            }
+        });
+
+        timeline.getKeyFrames().add(new KeyFrame(Duration.millis(3), event -> {
+            for (int i = 0; i < derivatives.length; i++) {
+                derivatives[i] *= frictions[i];
+            }
+            for (int i = 1; i < derivatives.length; i++) {
+                derivatives[i] += derivatives[i - 1];
+            }
+
+            double dy = derivatives[derivatives.length - 1];
+            Function<Bounds, Double> sizeFunction = (scrollDirection.get() == ScrollDirection.UP || scrollDirection.get() == ScrollDirection.DOWN) ? Bounds::getHeight : Bounds::getWidth;
+            double size = sizeFunction.apply(scrollPane.getContent().getLayoutBounds());
+            double value;
+            switch (scrollDirection.get()) {
+                case LEFT:
+                case RIGHT:
+                    value = Math.min(Math.max(scrollPane.hvalueProperty().get() + dy / size, 0), 1);
+                    scrollPane.hvalueProperty().set(value);
+                    break;
+                case UP:
+                case DOWN:
+                    value = Math.min(Math.max(scrollPane.vvalueProperty().get() + dy / size, 0), 1);
+                    scrollPane.vvalueProperty().set(value);
+                    break;
+            }
+
+            if (Math.abs(dy) < 0.001) {
+                timeline.stop();
+            }
+        }));
+        timeline.setCycleCount(Animation.INDEFINITE);
+    }
+
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/ToolbarListPageSkin.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui;
 
 import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -69,7 +68,7 @@ public abstract class ToolbarListPageSkin<T extends ListPageBase<? extends Node>
             Bindings.bindContent(content.getChildren(), skinnable.itemsProperty());
 
             scrollPane.setContent(content);
-            JFXScrollPane.smoothScrolling(scrollPane);
+            FXUtils.smoothScrolling(scrollPane);
 
             root.getContent().add(scrollPane);
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/account/AccountListPage.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.account;
 
 import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
 import javafx.beans.value.ObservableValue;
@@ -187,7 +186,7 @@ public class AccountListPage extends DecoratorAnimatedPage implements DecoratorP
                 Bindings.bindContent(list.getChildren(), skinnable.items);
 
                 scrollPane.setContent(list);
-                JFXScrollPane.smoothScrolling(scrollPane);
+                FXUtils.smoothScrolling(scrollPane);
 
                 setCenter(scrollPane);
             }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/AboutPage.java
@@ -17,13 +17,13 @@
  */
 package org.jackhuang.hmcl.ui.main;
 
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.geometry.Insets;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.image.Image;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import org.jackhuang.hmcl.Metadata;
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.construct.ComponentList;
 import org.jackhuang.hmcl.ui.construct.IconedTwoLineListItem;
 
@@ -191,7 +191,7 @@ public class AboutPage extends StackPane {
 
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
-        JFXScrollPane.smoothScrolling(scrollPane);
+        FXUtils.smoothScrolling(scrollPane);
         getChildren().setAll(scrollPane);
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -48,7 +48,7 @@ public class DownloadSettingsPage extends StackPane {
         content.setPadding(new Insets(10));
         content.setFillWidth(true);
         ScrollPane scrollPane = new ScrollPane(content);
-        JFXScrollPane.smoothScrolling(scrollPane);
+        FXUtils.smoothScrolling(scrollPane);
         scrollPane.setFitToWidth(true);
         getChildren().setAll(scrollPane);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/FeedbackPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/FeedbackPage.java
@@ -17,11 +17,11 @@
  */
 package org.jackhuang.hmcl.ui.main;
 
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.geometry.Insets;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.image.Image;
 import javafx.scene.layout.VBox;
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.construct.ComponentList;
 import org.jackhuang.hmcl.ui.construct.IconedTwoLineListItem;
 import org.jackhuang.hmcl.ui.construct.SpinnerPane;
@@ -37,7 +37,7 @@ public class FeedbackPage extends SpinnerPane {
         content.setFillWidth(true);
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
-        JFXScrollPane.smoothScrolling(scrollPane);
+        FXUtils.smoothScrolling(scrollPane);
         setContent(scrollPane);
 
         ComponentList community = new ComponentList();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/HelpPage.java
@@ -19,13 +19,13 @@ package org.jackhuang.hmcl.ui.main;
 
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.geometry.Insets;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.VBox;
 import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.task.Schedulers;
 import org.jackhuang.hmcl.task.Task;
+import org.jackhuang.hmcl.ui.FXUtils;
 import org.jackhuang.hmcl.ui.construct.ComponentList;
 import org.jackhuang.hmcl.ui.construct.IconedTwoLineListItem;
 import org.jackhuang.hmcl.ui.construct.SpinnerPane;
@@ -47,7 +47,7 @@ public class HelpPage extends SpinnerPane {
         content.setFillWidth(true);
         ScrollPane scrollPane = new ScrollPane(content);
         scrollPane.setFitToWidth(true);
-        JFXScrollPane.smoothScrolling(scrollPane);
+        FXUtils.smoothScrolling(scrollPane);
         setContent(scrollPane);
 
         IconedTwoLineListItem docPane = new IconedTwoLineListItem();

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/PersonalizationPage.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.main;
 
 import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXScrollPane;
 import com.jfoenix.controls.JFXTextField;
 import com.jfoenix.effects.JFXDepthManager;
 import javafx.application.Platform;
@@ -56,7 +55,7 @@ public class PersonalizationPage extends StackPane {
         content.setPadding(new Insets(10));
         content.setFillWidth(true);
         ScrollPane scrollPane = new ScrollPane(content);
-        JFXScrollPane.smoothScrolling(scrollPane);
+        FXUtils.smoothScrolling(scrollPane);
         scrollPane.setFitToWidth(true);
         getChildren().setAll(scrollPane);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -18,7 +18,6 @@
 package org.jackhuang.hmcl.ui.versions;
 
 import com.jfoenix.controls.JFXButton;
-import com.jfoenix.controls.JFXScrollPane;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
@@ -233,7 +232,7 @@ public class DownloadPage extends Control implements DecoratorPage {
             pane.getStyleClass().add("gray-background");
             pane.setPadding(new Insets(10));
             ScrollPane scrollPane = new ScrollPane(pane);
-            JFXScrollPane.smoothScrolling(scrollPane);
+            FXUtils.smoothScrolling(scrollPane);
             scrollPane.setFitToWidth(true);
             scrollPane.setFitToHeight(true);
 


### PR DESCRIPTION
JFoenix 的平滑滚动年久失修，导致了 GTK 3 上启用平滑滚动时无法向上滚动，以及触摸屏下的滚动速度问题。通过重写平滑滚动以解决这些问题。