### PR TITLE
修复下载源选择 ComboBox 过长的问题

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/DownloadSettingsPage.java
@@ -90,7 +90,7 @@ public class DownloadSettingsPage extends StackPane {
 
                     JFXComboBox<String> cboDownloadSource = new JFXComboBox<>();
                     cboDownloadSource.setConverter(stringConverter(key -> i18n("download.provider." + key)));
-                    downloadSourcePane.setCenter(cboDownloadSource);
+                    downloadSourcePane.setRight(cboDownloadSource);
                     FXUtils.setLimitWidth(cboDownloadSource, 420);
 
                     cboDownloadSource.getItems().setAll(DownloadProviders.rawProviders.keySet());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20694662/217545952-e34112d4-d204-4d07-9ad9-48e07be67445.png)
