### PR TITLE
Use computeIfAbsent in EventBus

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/event/EventBus.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/event/EventBus.java
@@ -31,8 +31,7 @@ public final class EventBus {
 
     @SuppressWarnings("unchecked")
     public <T extends Event> EventManager<T> channel(Class<T> clazz) {
-        events.putIfAbsent(clazz, new EventManager<>());
-        return (EventManager<T>) events.get(clazz);
+        return (EventManager<T>) events.computeIfAbsent(clazz, ignored -> new EventManager<>());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
避免在每次 `fireEvent` 时创建新的 `EventManager`。