### PR TITLE
将版本高级设置拆分至单独页面中

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/SVG.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/SVG.java
@@ -40,14 +40,15 @@ public final class SVG {
         if (fill != null)
             path.fillProperty().bind(fill);
 
-        if (width < 0 || height < 0) {
+        double scale;
+        if (width < 0 || height < 0 || (scale = Math.min(width / 24, height / 24)) == 1) {
             StackPane pane = new StackPane(path);
             pane.setAlignment(Pos.CENTER);
             return pane;
         }
 
         Group svg = new Group(path);
-        double scale = Math.min(width / 24, height / 24);
+
         svg.setScaleX(scale);
         svg.setScaleY(scale);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/SVG.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/SVG.java
@@ -40,15 +40,14 @@ public final class SVG {
         if (fill != null)
             path.fillProperty().bind(fill);
 
-        double scale;
-        if (width < 0 || height < 0 || (scale = Math.min(width / 24, height / 24)) == 1) {
+        if (width < 0 || height < 0) {
             StackPane pane = new StackPane(path);
             pane.setAlignment(Pos.CENTER);
             return pane;
         }
 
         Group svg = new Group(path);
-
+        double scale = Math.min(width / 24, height / 24);
         svg.setScaleX(scale);
         svg.setScaleY(scale);
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
@@ -1,0 +1,235 @@
+package org.jackhuang.hmcl.ui.versions;
+
+import com.jfoenix.controls.JFXTextField;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.*;
+import org.jackhuang.hmcl.game.NativesDirectoryType;
+import org.jackhuang.hmcl.setting.Profile;
+import org.jackhuang.hmcl.setting.VersionSetting;
+import org.jackhuang.hmcl.ui.FXUtils;
+import org.jackhuang.hmcl.ui.construct.*;
+import org.jackhuang.hmcl.ui.decorator.DecoratorPage;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+
+public final class AdvancedVersionSettingPage extends StackPane implements DecoratorPage {
+
+    private final ObjectProperty<State> stateProperty;
+
+    private final Profile profile;
+    private final String versionId;
+    private final VersionSetting versionSetting;
+
+    private final JFXTextField txtJVMArgs;
+    private final JFXTextField txtGameArgs;
+    private final JFXTextField txtMetaspace;
+    private final JFXTextField txtWrapper;
+    private final JFXTextField txtPreLaunchCommand;
+    private final JFXTextField txtPostExitCommand;
+    private final OptionToggleButton noJVMArgsPane;
+    private final OptionToggleButton noGameCheckPane;
+    private final OptionToggleButton noJVMCheckPane;
+    private final OptionToggleButton noNativesPatchPane;
+    private final OptionToggleButton useSoftwareRenderer;
+    private final OptionToggleButton useNativeGLFWPane;
+    private final OptionToggleButton useNativeOpenALPane;
+    private final ComponentSublist nativesDirSublist;
+    private final MultiFileItem<NativesDirectoryType> nativesDirItem;
+    private final MultiFileItem.FileOption<NativesDirectoryType> nativesDirCustomOption;
+
+    public AdvancedVersionSettingPage(Profile profile, String versionId, VersionSetting versionSetting) {
+        this.profile = profile;
+        this.versionId = versionId;
+        this.versionSetting = versionSetting;
+        this.stateProperty = new SimpleObjectProperty<>(State.fromTitle(
+                versionId == null ? i18n("settings.advanced") : i18n("settings.advanced.title", versionId)
+        ));
+
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setFitToHeight(true);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        getChildren().setAll(scrollPane);
+
+        VBox rootPane = new VBox();
+        rootPane.setFillWidth(true);
+        scrollPane.setContent(rootPane);
+        FXUtils.smoothScrolling(scrollPane);
+        rootPane.getStyleClass().add("card-list");
+
+        ComponentList customCommandsPane = new ComponentList();
+        {
+            GridPane pane = new GridPane();
+            pane.setHgap(16);
+            pane.setVgap(8);
+            pane.getColumnConstraints().setAll(new ColumnConstraints(), FXUtils.getColumnHgrowing());
+
+            txtGameArgs = new JFXTextField();
+            txtGameArgs.setPromptText(i18n("settings.advanced.minecraft_arguments.prompt"));
+            txtGameArgs.getStyleClass().add("fit-width");
+            pane.addRow(0, new Label(i18n("settings.advanced.minecraft_arguments")), txtGameArgs);
+
+            txtPreLaunchCommand = new JFXTextField();
+            txtPreLaunchCommand.setPromptText(i18n("settings.advanced.precall_command.prompt"));
+            txtPreLaunchCommand.getStyleClass().add("fit-width");
+            pane.addRow(1, new Label(i18n("settings.advanced.precall_command")), txtPreLaunchCommand);
+
+            txtWrapper = new JFXTextField();
+            txtWrapper.setPromptText(i18n("settings.advanced.wrapper_launcher.prompt"));
+            txtWrapper.getStyleClass().add("fit-width");
+            pane.addRow(2, new Label(i18n("settings.advanced.wrapper_launcher")), txtWrapper);
+
+            txtPostExitCommand = new JFXTextField();
+            txtPostExitCommand.setPromptText(i18n("settings.advanced.post_exit_command.prompt"));
+            txtPostExitCommand.getStyleClass().add("fit-width");
+            pane.addRow(3, new Label(i18n("settings.advanced.post_exit_command")), txtPostExitCommand);
+
+            HintPane hintPane = new HintPane();
+            hintPane.setText(i18n("settings.advanced.custom_commands.hint"));
+            GridPane.setColumnSpan(hintPane, 2);
+            pane.addRow(4, hintPane);
+
+            customCommandsPane.getContent().setAll(pane);
+        }
+
+        ComponentList jvmPane = new ComponentList();
+        {
+            GridPane pane = new GridPane();
+            ColumnConstraints title = new ColumnConstraints();
+            ColumnConstraints value = new ColumnConstraints();
+            value.setFillWidth(true);
+            value.setHgrow(Priority.ALWAYS);
+            pane.setHgap(16);
+            pane.setVgap(8);
+            pane.getColumnConstraints().setAll(title, value);
+
+            txtJVMArgs = new JFXTextField();
+            txtJVMArgs.getStyleClass().add("fit-width");
+            pane.addRow(0, new Label(i18n("settings.advanced.jvm_args")), txtJVMArgs);
+
+            HintPane hintPane = new HintPane();
+            hintPane.setText(i18n("settings.advanced.jvm_args.prompt"));
+            GridPane.setColumnSpan(hintPane, 2);
+            pane.addRow(4, hintPane);
+
+            txtMetaspace = new JFXTextField();
+            txtMetaspace.setPromptText(i18n("settings.advanced.java_permanent_generation_space.prompt"));
+            txtMetaspace.getStyleClass().add("fit-width");
+            FXUtils.setValidateWhileTextChanged(txtMetaspace, true);
+            txtMetaspace.setValidators(new NumberValidator(i18n("input.number"), true));
+            pane.addRow(1, new Label(i18n("settings.advanced.java_permanent_generation_space")), txtMetaspace);
+
+            jvmPane.getContent().setAll(pane);
+        }
+
+        ComponentList workaroundPane = new ComponentList();
+
+        HintPane workaroundWarning = new HintPane(MessageDialogPane.MessageType.WARNING);
+        workaroundWarning.setText(i18n("settings.advanced.workaround.warning"));
+
+        {
+            nativesDirItem = new MultiFileItem<>();
+            nativesDirSublist = new ComponentSublist();
+            nativesDirSublist.getContent().add(nativesDirItem);
+            nativesDirSublist.setTitle(i18n("settings.advanced.natives_directory"));
+            nativesDirSublist.setHasSubtitle(true);
+            nativesDirCustomOption = new MultiFileItem.FileOption<>(i18n("settings.advanced.natives_directory.custom"), NativesDirectoryType.CUSTOM)
+                    .setChooserTitle(i18n("settings.advanced.natives_directory.choose"))
+                    .setDirectory(true);
+            nativesDirItem.loadChildren(Arrays.asList(
+                    new MultiFileItem.Option<>(i18n("settings.advanced.natives_directory.default"), NativesDirectoryType.VERSION_FOLDER),
+                    nativesDirCustomOption
+            ));
+            HintPane nativesDirHint = new HintPane(MessageDialogPane.MessageType.WARNING);
+            nativesDirHint.setText(i18n("settings.advanced.natives_directory.hint"));
+            nativesDirItem.getChildren().add(nativesDirHint);
+
+            noJVMArgsPane = new OptionToggleButton();
+            noJVMArgsPane.setTitle(i18n("settings.advanced.no_jvm_args"));
+
+            noGameCheckPane = new OptionToggleButton();
+            noGameCheckPane.setTitle(i18n("settings.advanced.dont_check_game_completeness"));
+
+            noJVMCheckPane = new OptionToggleButton();
+            noJVMCheckPane.setTitle(i18n("settings.advanced.dont_check_jvm_validity"));
+
+            noNativesPatchPane = new OptionToggleButton();
+            noNativesPatchPane.setTitle(i18n("settings.advanced.dont_patch_natives"));
+
+            useSoftwareRenderer = new OptionToggleButton();
+            useSoftwareRenderer.setTitle(i18n("settings.advanced.use_software_renderer"));
+
+            useNativeGLFWPane = new OptionToggleButton();
+            useNativeGLFWPane.setTitle(i18n("settings.advanced.use_native_glfw"));
+
+            useNativeOpenALPane = new OptionToggleButton();
+            useNativeOpenALPane.setTitle(i18n("settings.advanced.use_native_openal"));
+
+            workaroundPane.getContent().setAll(
+                    nativesDirSublist,
+                    noJVMArgsPane, noGameCheckPane, noJVMCheckPane, noNativesPatchPane,
+                    useSoftwareRenderer, useNativeGLFWPane, useNativeOpenALPane);
+        }
+
+        rootPane.getChildren().addAll(
+                ComponentList.createComponentListTitle(i18n("settings.advanced.custom_commands")), customCommandsPane,
+                ComponentList.createComponentListTitle(i18n("settings.advanced.jvm")), jvmPane,
+                ComponentList.createComponentListTitle(i18n("settings.advanced.workaround")), workaroundWarning, workaroundPane
+        );
+
+        bindProperties();
+    }
+
+    void bindProperties() {
+        nativesDirCustomOption.bindBidirectional(versionSetting.nativesDirProperty());
+        FXUtils.bindString(txtJVMArgs, versionSetting.javaArgsProperty());
+        FXUtils.bindString(txtGameArgs, versionSetting.minecraftArgsProperty());
+        FXUtils.bindString(txtMetaspace, versionSetting.permSizeProperty());
+        FXUtils.bindString(txtWrapper, versionSetting.wrapperProperty());
+        FXUtils.bindString(txtPreLaunchCommand, versionSetting.preLaunchCommandProperty());
+        noGameCheckPane.selectedProperty().bindBidirectional(versionSetting.notCheckGameProperty());
+        noJVMCheckPane.selectedProperty().bindBidirectional(versionSetting.notCheckJVMProperty());
+        noJVMArgsPane.selectedProperty().bindBidirectional(versionSetting.noJVMArgsProperty());
+        noNativesPatchPane.selectedProperty().bindBidirectional(versionSetting.notPatchNativesProperty());
+        useSoftwareRenderer.selectedProperty().bindBidirectional(versionSetting.useSoftwareRendererProperty());
+        useNativeGLFWPane.selectedProperty().bindBidirectional(versionSetting.useNativeGLFWProperty());
+        useNativeOpenALPane.selectedProperty().bindBidirectional(versionSetting.useNativeOpenALProperty());
+
+        nativesDirItem.selectedDataProperty().bindBidirectional(versionSetting.nativesDirTypeProperty());
+        nativesDirSublist.subtitleProperty().bind(Bindings.createStringBinding(() -> Paths.get(profile.getRepository().getRunDirectory(versionId).getAbsolutePath() + "/natives").normalize().toString(),
+                versionSetting.nativesDirProperty(), versionSetting.nativesDirTypeProperty()));
+    }
+
+    void unbindProperties() {
+        nativesDirCustomOption.valueProperty().unbindBidirectional(versionSetting.nativesDirProperty());
+        FXUtils.unbind(txtJVMArgs, versionSetting.javaArgsProperty());
+        FXUtils.unbind(txtGameArgs, versionSetting.minecraftArgsProperty());
+        FXUtils.unbind(txtMetaspace, versionSetting.permSizeProperty());
+        FXUtils.unbind(txtWrapper, versionSetting.wrapperProperty());
+        FXUtils.unbind(txtPreLaunchCommand, versionSetting.preLaunchCommandProperty());
+        FXUtils.unbind(txtPostExitCommand, versionSetting.postExitCommandProperty());
+        noGameCheckPane.selectedProperty().unbindBidirectional(versionSetting.notCheckGameProperty());
+        noJVMCheckPane.selectedProperty().unbindBidirectional(versionSetting.notCheckJVMProperty());
+        noJVMArgsPane.selectedProperty().unbindBidirectional(versionSetting.noJVMArgsProperty());
+        noNativesPatchPane.selectedProperty().unbindBidirectional(versionSetting.notPatchNativesProperty());
+        useSoftwareRenderer.selectedProperty().unbindBidirectional(versionSetting.useSoftwareRendererProperty());
+        useNativeGLFWPane.selectedProperty().unbindBidirectional(versionSetting.useNativeGLFWProperty());
+        useNativeOpenALPane.selectedProperty().unbindBidirectional(versionSetting.useNativeOpenALProperty());
+
+        nativesDirItem.selectedDataProperty().unbindBidirectional(versionSetting.nativesDirTypeProperty());
+        nativesDirSublist.subtitleProperty().unbind();
+    }
+
+    @Override
+    public ReadOnlyObjectProperty<State> stateProperty() {
+        return stateProperty;
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -127,9 +127,8 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             text.textProperty().bind(BindingMapping.of(selectedVersion)
                     .map(selectedVersion -> i18n("settings.type.special.edit.hint", selectedVersion)));
 
-            JFXHyperlink specificSettingsLink = new JFXHyperlink();
-            specificSettingsLink.setText(i18n("settings.type.special.edit"));
-            specificSettingsLink.setOnMouseClicked(e -> editSpecificSettings());
+            JFXHyperlink specificSettingsLink = new JFXHyperlink(i18n("settings.type.special.edit"));
+            specificSettingsLink.setOnAction(e -> editSpecificSettings());
 
             specificSettingsHint.setChildren(text, specificSettingsLink);
             specificSettingsHint.managedProperty().bind(navigateToSpecificSettings);
@@ -167,7 +166,7 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             settingsTypePane.setRight(editGlobalSettingsButton);
             editGlobalSettingsButton.disableProperty().bind(enableSpecificCheckBox.selectedProperty());
             BorderPane.setAlignment(editGlobalSettingsButton, Pos.CENTER_RIGHT);
-            editGlobalSettingsButton.setOnMouseClicked(e -> editGlobalSettings());
+            editGlobalSettingsButton.setOnAction(e -> editGlobalSettings());
         }
 
         {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -66,8 +66,6 @@ import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
 public final class VersionSettingsPage extends StackPane implements DecoratorPage, VersionPage.VersionLoadable, PageAware {
     private final ReadOnlyObjectWrapper<State> state = new ReadOnlyObjectWrapper<>(new State("", null, false, false, false));
 
-    private final boolean globalSetting;
-
     private AdvancedVersionSettingPage advancedVersionSettingPage;
 
     private VersionSetting lastVersionSetting = null;
@@ -107,8 +105,6 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
     private final BooleanProperty modpack = new SimpleBooleanProperty();
 
     public VersionSettingsPage(boolean globalSetting) {
-        this.globalSetting = globalSetting;
-
         ScrollPane scrollPane = new ScrollPane();
         scrollPane.setFitToHeight(true);
         scrollPane.setFitToWidth(true);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/VersionSettingsPage.java
@@ -68,6 +68,8 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
 
     private final boolean globalSetting;
 
+    private AdvancedVersionSettingPage advancedVersionSettingPage;
+
     private VersionSetting lastVersionSetting = null;
     private Profile profile;
     private WeakListenerHolder listenerHolder;
@@ -77,24 +79,11 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
     private final VBox rootPane;
     private final JFXTextField txtWidth;
     private final JFXTextField txtHeight;
-    private final JFXTextField txtJVMArgs;
-    private final JFXTextField txtGameArgs;
-    private final JFXTextField txtMetaspace;
-    private final JFXTextField txtWrapper;
-    private final JFXTextField txtPreLaunchCommand;
-    private final JFXTextField txtPostExitCommand;
     private final JFXTextField txtServerIP;
     private final ComponentList componentList;
     private final JFXComboBox<LauncherVisibility> cboLauncherVisibility;
     private final JFXCheckBox chkAutoAllocate;
     private final JFXCheckBox chkFullscreen;
-    private final OptionToggleButton noJVMArgsPane;
-    private final OptionToggleButton noGameCheckPane;
-    private final OptionToggleButton noJVMCheckPane;
-    private final OptionToggleButton noNativesPatchPane;
-    private final OptionToggleButton useSoftwareRenderer;
-    private final OptionToggleButton useNativeGLFWPane;
-    private final OptionToggleButton useNativeOpenALPane;
     private final ComponentSublist javaSublist;
     private final MultiFileItem<Pair<JavaVersionType, JavaVersion>> javaItem;
     private final MultiFileItem.Option<Pair<JavaVersionType, JavaVersion>> javaAutoDeterminedOption;
@@ -102,12 +91,9 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
     private final ComponentSublist gameDirSublist;
     private final MultiFileItem<GameDirectoryType> gameDirItem;
     private final MultiFileItem.FileOption<GameDirectoryType> gameDirCustomOption;
-    private final ComponentSublist nativesDirSublist;
-    private final MultiFileItem<NativesDirectoryType> nativesDirItem;
-    private final MultiFileItem.FileOption<NativesDirectoryType> nativesDirCustomOption;
     private final JFXComboBox<ProcessPriority> cboProcessPriority;
     private final OptionToggleButton showLogsPane;
-    private ImagePickerItem iconPickerItem;
+    private final ImagePickerItem iconPickerItem;
 
     private final InvalidationListener specificSettingsListener;
 
@@ -153,10 +139,10 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             specificSettingsHint.managedProperty().bind(navigateToSpecificSettings);
             specificSettingsHint.visibleProperty().bind(navigateToSpecificSettings);
 
-            rootPane.getChildren().addAll(specificSettingsHint);
-        }
+            iconPickerItem = null;
 
-        if (!globalSetting) {
+            rootPane.getChildren().addAll(specificSettingsHint);
+        } else {
             HintPane gameDirHint = new HintPane(MessageDialogPane.MessageType.INFO);
             gameDirHint.setText(i18n("settings.game.working_directory.hint"));
             rootPane.getChildren().add(gameDirHint);
@@ -170,7 +156,6 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             iconPickerItem.setOnSelectButtonClicked(e -> onExploreIcon());
             iconPickerItem.setOnDeleteButtonClicked(e -> onDeleteIcon());
             iconPickerItemWrapper.getContent().setAll(iconPickerItem);
-
 
             BorderPane settingsTypePane = new BorderPane();
             settingsTypePane.disableProperty().bind(modpack);
@@ -401,146 +386,43 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
                 serverPane.addRow(0, new Label(i18n("settings.advanced.server_ip")), txtServerIP);
             }
 
-            componentList.getContent().setAll(javaSublist, gameDirSublist, maxMemoryPane, launcherVisibilityPane, dimensionPane, showLogsPane, processPriorityPane, serverPane);
+            BorderPane showAdvancedSettingPane = new BorderPane();
+            {
+                Label label = new Label(i18n("settings.advanced"));
+                showAdvancedSettingPane.setLeft(label);
+                BorderPane.setAlignment(label, Pos.CENTER_LEFT);
+
+                JFXButton button = new JFXButton(i18n("settings.advanced.modify"));
+                button.setOnAction(e -> {
+                    if (lastVersionSetting != null) {
+                        if (advancedVersionSettingPage == null)
+                            advancedVersionSettingPage = new AdvancedVersionSettingPage(profile, versionId, lastVersionSetting);
+
+                        Controllers.navigate(advancedVersionSettingPage);
+                    }
+                });
+                button.getStyleClass().add("jfx-button-border");
+                showAdvancedSettingPane.setRight(button);
+            }
+
+            componentList.getContent().setAll(
+                    javaSublist,
+                    gameDirSublist,
+                    maxMemoryPane,
+                    launcherVisibilityPane,
+                    dimensionPane,
+                    showLogsPane,
+                    processPriorityPane,
+                    serverPane,
+                    showAdvancedSettingPane
+            );
         }
 
-        HBox advancedHintPane = new HBox();
-        advancedHintPane.setAlignment(Pos.CENTER);
-        advancedHintPane.setPadding(new Insets(16, 0, 8, 0));
-        {
-            Label advanced = new Label(i18n("settings.advanced"));
-            advanced.setStyle("-fx-font-size: 12px;");
-            advancedHintPane.getChildren().setAll(advanced);
-        }
-
-        ComponentList customCommandsPane = new ComponentList();
-        customCommandsPane.disableProperty().bind(enableSpecificSettings.not());
-        {
-            GridPane pane = new GridPane();
-            pane.setHgap(16);
-            pane.setVgap(8);
-            pane.getColumnConstraints().setAll(new ColumnConstraints(), FXUtils.getColumnHgrowing());
-
-            txtGameArgs = new JFXTextField();
-            txtGameArgs.setPromptText(i18n("settings.advanced.minecraft_arguments.prompt"));
-            txtGameArgs.getStyleClass().add("fit-width");
-            pane.addRow(0, new Label(i18n("settings.advanced.minecraft_arguments")), txtGameArgs);
-
-            txtPreLaunchCommand = new JFXTextField();
-            txtPreLaunchCommand.setPromptText(i18n("settings.advanced.precall_command.prompt"));
-            txtPreLaunchCommand.getStyleClass().add("fit-width");
-            pane.addRow(1, new Label(i18n("settings.advanced.precall_command")), txtPreLaunchCommand);
-
-            txtWrapper = new JFXTextField();
-            txtWrapper.setPromptText(i18n("settings.advanced.wrapper_launcher.prompt"));
-            txtWrapper.getStyleClass().add("fit-width");
-            pane.addRow(2, new Label(i18n("settings.advanced.wrapper_launcher")), txtWrapper);
-
-            txtPostExitCommand = new JFXTextField();
-            txtPostExitCommand.setPromptText(i18n("settings.advanced.post_exit_command.prompt"));
-            txtPostExitCommand.getStyleClass().add("fit-width");
-            pane.addRow(3, new Label(i18n("settings.advanced.post_exit_command")), txtPostExitCommand);
-
-            HintPane hintPane = new HintPane();
-            hintPane.setText(i18n("settings.advanced.custom_commands.hint"));
-            GridPane.setColumnSpan(hintPane, 2);
-            pane.addRow(4, hintPane);
-
-            customCommandsPane.getContent().setAll(pane);
-        }
-
-        ComponentList jvmPane = new ComponentList();
-        jvmPane.disableProperty().bind(enableSpecificSettings.not());
-        {
-            GridPane pane = new GridPane();
-            ColumnConstraints title = new ColumnConstraints();
-            ColumnConstraints value = new ColumnConstraints();
-            value.setFillWidth(true);
-            value.setHgrow(Priority.ALWAYS);
-            pane.setHgap(16);
-            pane.setVgap(8);
-            pane.getColumnConstraints().setAll(title, value);
-
-            txtJVMArgs = new JFXTextField();
-            txtJVMArgs.getStyleClass().add("fit-width");
-            pane.addRow(0, new Label(i18n("settings.advanced.jvm_args")), txtJVMArgs);
-
-            HintPane hintPane = new HintPane();
-            hintPane.setText(i18n("settings.advanced.jvm_args.prompt"));
-            GridPane.setColumnSpan(hintPane, 2);
-            pane.addRow(4, hintPane);
-
-            txtMetaspace = new JFXTextField();
-            txtMetaspace.setPromptText(i18n("settings.advanced.java_permanent_generation_space.prompt"));
-            txtMetaspace.getStyleClass().add("fit-width");
-            FXUtils.setValidateWhileTextChanged(txtMetaspace, true);
-            txtMetaspace.setValidators(new NumberValidator(i18n("input.number"), true));
-            pane.addRow(1, new Label(i18n("settings.advanced.java_permanent_generation_space")), txtMetaspace);
-
-            jvmPane.getContent().setAll(pane);
-        }
-
-        ComponentList workaroundPane = new ComponentList();
-        workaroundPane.disableProperty().bind(enableSpecificSettings.not());
-
-        HintPane workaroundWarning = new HintPane(MessageDialogPane.MessageType.WARNING);
-        workaroundWarning.setText(i18n("settings.advanced.workaround.warning"));
-
-        {
-            nativesDirItem = new MultiFileItem<>();
-            nativesDirSublist = new ComponentSublist();
-            nativesDirSublist.getContent().add(nativesDirItem);
-            nativesDirSublist.setTitle(i18n("settings.advanced.natives_directory"));
-            nativesDirSublist.setHasSubtitle(true);
-            nativesDirCustomOption = new MultiFileItem.FileOption<>(i18n("settings.advanced.natives_directory.custom"), NativesDirectoryType.CUSTOM)
-                    .setChooserTitle(i18n("settings.advanced.natives_directory.choose"))
-                    .setDirectory(true);
-            nativesDirItem.loadChildren(Arrays.asList(
-                    new MultiFileItem.Option<>(i18n("settings.advanced.natives_directory.default"), NativesDirectoryType.VERSION_FOLDER),
-                    nativesDirCustomOption
-            ));
-            HintPane nativesDirHint = new HintPane(MessageDialogPane.MessageType.WARNING);
-            nativesDirHint.setText(i18n("settings.advanced.natives_directory.hint"));
-            nativesDirItem.getChildren().add(nativesDirHint);
-
-            noJVMArgsPane = new OptionToggleButton();
-            noJVMArgsPane.setTitle(i18n("settings.advanced.no_jvm_args"));
-
-            noGameCheckPane = new OptionToggleButton();
-            noGameCheckPane.setTitle(i18n("settings.advanced.dont_check_game_completeness"));
-
-            noJVMCheckPane = new OptionToggleButton();
-            noJVMCheckPane.setTitle(i18n("settings.advanced.dont_check_jvm_validity"));
-
-            noNativesPatchPane = new OptionToggleButton();
-            noNativesPatchPane.setTitle(i18n("settings.advanced.dont_patch_natives"));
-
-            useSoftwareRenderer = new OptionToggleButton();
-            useSoftwareRenderer.setTitle(i18n("settings.advanced.use_software_renderer"));
-
-            useNativeGLFWPane = new OptionToggleButton();
-            useNativeGLFWPane.setTitle(i18n("settings.advanced.use_native_glfw"));
-
-            useNativeOpenALPane = new OptionToggleButton();
-            useNativeOpenALPane.setTitle(i18n("settings.advanced.use_native_openal"));
-
-            workaroundPane.getContent().setAll(
-                    nativesDirSublist,
-                    noJVMArgsPane, noGameCheckPane, noJVMCheckPane, noNativesPatchPane,
-                    useSoftwareRenderer, useNativeGLFWPane, useNativeOpenALPane);
-        }
-
-        rootPane.getChildren().addAll(componentList,
-                advancedHintPane,
-                ComponentList.createComponentListTitle(i18n("settings.advanced.custom_commands")), customCommandsPane,
-                ComponentList.createComponentListTitle(i18n("settings.advanced.jvm")), jvmPane,
-                ComponentList.createComponentListTitle(i18n("settings.advanced.workaround")), workaroundWarning, workaroundPane);
+        rootPane.getChildren().add(componentList);
 
         initialize();
 
-        specificSettingsListener = any -> {
-            enableSpecificSettings.set(!lastVersionSetting.isUsesGlobal());
-        };
+        specificSettingsListener = any -> enableSpecificSettings.set(!lastVersionSetting.isUsesGlobal());
 
         addEventHandler(Navigator.NavigationEvent.NAVIGATED, this::onDecoratorPageNavigating);
 
@@ -631,24 +513,10 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             maxMemory.unbindBidirectional(lastVersionSetting.maxMemoryProperty());
             javaCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.javaDirProperty());
             gameDirCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.gameDirProperty());
-            nativesDirCustomOption.valueProperty().unbindBidirectional(lastVersionSetting.nativesDirProperty());
-            FXUtils.unbind(txtJVMArgs, lastVersionSetting.javaArgsProperty());
-            FXUtils.unbind(txtGameArgs, lastVersionSetting.minecraftArgsProperty());
-            FXUtils.unbind(txtMetaspace, lastVersionSetting.permSizeProperty());
-            FXUtils.unbind(txtWrapper, lastVersionSetting.wrapperProperty());
-            FXUtils.unbind(txtPreLaunchCommand, lastVersionSetting.preLaunchCommandProperty());
-            FXUtils.unbind(txtPostExitCommand, lastVersionSetting.postExitCommandProperty());
             FXUtils.unbind(txtServerIP, lastVersionSetting.serverIpProperty());
             FXUtils.unbindBoolean(chkAutoAllocate, lastVersionSetting.autoMemoryProperty());
             FXUtils.unbindBoolean(chkFullscreen, lastVersionSetting.fullscreenProperty());
-            noGameCheckPane.selectedProperty().unbindBidirectional(lastVersionSetting.notCheckGameProperty());
-            noJVMCheckPane.selectedProperty().unbindBidirectional(lastVersionSetting.notCheckJVMProperty());
-            noJVMArgsPane.selectedProperty().unbindBidirectional(lastVersionSetting.noJVMArgsProperty());
-            noNativesPatchPane.selectedProperty().unbindBidirectional(lastVersionSetting.notPatchNativesProperty());
             showLogsPane.selectedProperty().unbindBidirectional(lastVersionSetting.showLogsProperty());
-            useSoftwareRenderer.selectedProperty().unbindBidirectional(lastVersionSetting.useSoftwareRendererProperty());
-            useNativeGLFWPane.selectedProperty().unbindBidirectional(lastVersionSetting.useNativeGLFWProperty());
-            useNativeOpenALPane.selectedProperty().unbindBidirectional(lastVersionSetting.useNativeOpenALProperty());
             FXUtils.unbindEnum(cboLauncherVisibility);
             FXUtils.unbindEnum(cboProcessPriority);
 
@@ -659,8 +527,10 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
             gameDirItem.selectedDataProperty().unbindBidirectional(lastVersionSetting.gameDirTypeProperty());
             gameDirSublist.subtitleProperty().unbind();
 
-            nativesDirItem.selectedDataProperty().unbindBidirectional(lastVersionSetting.nativesDirTypeProperty());
-            nativesDirSublist.subtitleProperty().unbind();
+            if (advancedVersionSettingPage != null) {
+                advancedVersionSettingPage.unbindProperties();
+                advancedVersionSettingPage = null;
+            }
         }
 
         // unbind data fields
@@ -673,23 +543,10 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
 
         javaCustomOption.bindBidirectional(versionSetting.javaDirProperty());
         gameDirCustomOption.bindBidirectional(versionSetting.gameDirProperty());
-        nativesDirCustomOption.bindBidirectional(versionSetting.nativesDirProperty());
-        FXUtils.bindString(txtJVMArgs, versionSetting.javaArgsProperty());
-        FXUtils.bindString(txtGameArgs, versionSetting.minecraftArgsProperty());
-        FXUtils.bindString(txtMetaspace, versionSetting.permSizeProperty());
-        FXUtils.bindString(txtWrapper, versionSetting.wrapperProperty());
-        FXUtils.bindString(txtPreLaunchCommand, versionSetting.preLaunchCommandProperty());
         FXUtils.bindString(txtServerIP, versionSetting.serverIpProperty());
         FXUtils.bindBoolean(chkAutoAllocate, versionSetting.autoMemoryProperty());
         FXUtils.bindBoolean(chkFullscreen, versionSetting.fullscreenProperty());
-        noGameCheckPane.selectedProperty().bindBidirectional(versionSetting.notCheckGameProperty());
-        noJVMCheckPane.selectedProperty().bindBidirectional(versionSetting.notCheckJVMProperty());
-        noJVMArgsPane.selectedProperty().bindBidirectional(versionSetting.noJVMArgsProperty());
-        noNativesPatchPane.selectedProperty().bindBidirectional(versionSetting.notPatchNativesProperty());
         showLogsPane.selectedProperty().bindBidirectional(versionSetting.showLogsProperty());
-        useSoftwareRenderer.selectedProperty().bindBidirectional(versionSetting.useSoftwareRendererProperty());
-        useNativeGLFWPane.selectedProperty().bindBidirectional(versionSetting.useNativeGLFWProperty());
-        useNativeOpenALPane.selectedProperty().bindBidirectional(versionSetting.useNativeOpenALProperty());
         FXUtils.bindEnum(cboLauncherVisibility, versionSetting.launcherVisibilityProperty());
         FXUtils.bindEnum(cboProcessPriority, versionSetting.processPriorityProperty());
 
@@ -715,10 +572,6 @@ public final class VersionSettingsPage extends StackPane implements DecoratorPag
         gameDirItem.selectedDataProperty().bindBidirectional(versionSetting.gameDirTypeProperty());
         gameDirSublist.subtitleProperty().bind(Bindings.createStringBinding(() -> Paths.get(profile.getRepository().getRunDirectory(versionId).getAbsolutePath()).normalize().toString(),
                 versionSetting.gameDirProperty(), versionSetting.gameDirTypeProperty()));
-
-        nativesDirItem.selectedDataProperty().bindBidirectional(versionSetting.nativesDirTypeProperty());
-        nativesDirSublist.subtitleProperty().bind(Bindings.createStringBinding(() -> Paths.get(profile.getRepository().getRunDirectory(versionId).getAbsolutePath() + "/natives").normalize().toString(),
-                versionSetting.nativesDirProperty(), versionSetting.nativesDirTypeProperty()));
 
         lastVersionSetting = versionSetting;
 

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -952,6 +952,8 @@ selector.custom=Custom
 settings=Settings
 
 settings.advanced=Advanced Settings
+settings.advanced.modify=Modify Advanced Settings
+settings.advanced.title=Advanced Settings - %s
 settings.advanced.custom_commands=Custom Commands
 settings.advanced.custom_commands.hint=The following environment variables are provided\:\n\
   - $INST_NAME: version name\n\

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -869,6 +869,7 @@ selector.custom=Personalizar
 settings=Configuración
 
 settings.advanced=Configuración avanzada
+settings.advanced.title=Configuración avanzada - %s
 settings.advanced.custom_commands=Comandos personalizados
 settings.advanced.custom_commands.hint=Se proporcionan las siguientes variables de entorno\:\n\
   - $INST_NAME: nombre de la versión\n\

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -703,6 +703,7 @@ selector.custom=カスタム
 settings=設定
 
 settings.advanced=詳細設定
+settings.advanced.title=詳細設定 - %s
 settings.advanced.custom_commands=カスタムコマンド
 settings.advanced.custom_commands.hint=カスタムコマンドは、次の環境変数を使用して実行されます。\n \
   \-$ INST_NAME：バージョンの名前\n \

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -708,6 +708,7 @@ selector.custom=Пользовательский
 settings=Настройки
 
 settings.advanced=Расширенные настройки
+settings.advanced.title=Расширенные настройки - %s
 settings.advanced.custom_commands=Пользовательские команды
 settings.advanced.custom_commands.hint=Пользовательские команды выполняются со следующими переменными окружения:\n\
   \  - $INST_NAME: название версии\n\

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -827,6 +827,8 @@ selector.custom=自訂
 settings=遊戲設定
 
 settings.advanced=進階設定
+settings.advanced.modify=修改進階設定
+settings.advanced.title=進階設定 - %s
 settings.advanced.custom_commands=自訂命令
 settings.advanced.custom_commands.hint=自訂命令被調用時將包含如下的環境變數：\n\
   \  - $INST_NAME: 版本名稱\n\
@@ -880,7 +882,7 @@ settings.advanced.use_native_glfw=[Linux] 使用系統 GLFW
 settings.advanced.use_native_openal=[Linux] 使用系統 OpenAL
 settings.advanced.use_software_renderer=使用 OpenGL 軟渲染器（相容性更好，但效能較差）
 settings.advanced.workaround=除錯選項
-settings.advanced.workaround.warning=除錯選項僅提供給專業玩家使用。修改除錯選項可能會導致遊戲無法啟動。除非你知道你在做什麼，否則請你不要修改這些選項。
+settings.advanced.workaround.warning=除錯選項僅提供給專業玩家使用。修改除錯選項可能會導致遊戲無法啟動。除非你知道你在做什麼，否則請不要修改這些選項。
 settings.advanced.wrapper_launcher=前置指令
 settings.advanced.wrapper_launcher.prompt=如填寫 optirun 後，啟動命令將從 "java ..." 變為 "optirun java ..."
 

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -825,6 +825,8 @@ selector.custom=自定义
 settings=设置
 
 settings.advanced=高级设置
+settings.advanced.modify=修改高级设置
+settings.advanced.title=高级设置 - %s
 settings.advanced.custom_commands=自定义命令
 settings.advanced.custom_commands.hint=自定义命令被调用时将包含如下的环境变量：\n\
   \  - $INST_NAME: 版本名称\n\
@@ -878,7 +880,7 @@ settings.advanced.use_native_glfw=[Linux] 使用系统 GLFW
 settings.advanced.use_native_openal=[Linux] 使用系统 OpenAL
 settings.advanced.use_software_renderer=使用 OpenGL 软渲染器（兼容性更好，但性能较差）
 settings.advanced.workaround=调试选项
-settings.advanced.workaround.warning=调试选项仅提供给专业玩家使用。调试选项可能会导致游戏无法启动。除非你知道你在做什么，否则请你不要修改这些选项！
+settings.advanced.workaround.warning=调试选项仅提供给专业玩家使用。调试选项可能会导致游戏无法启动。除非你知道你在做什么，否则请不要修改这些选项！
 settings.advanced.wrapper_launcher=包装命令
 settings.advanced.wrapper_launcher.prompt=如填写 optirun 后，启动命令将从 "java ..." 变为 "optirun java ..."
 


### PR DESCRIPTION
目前版本设置页包含大量设置项，每次点开都需要初始化很多控件，配置较差的机器上会引发秒级的界面卡顿。

由于游戏管理和启动器设置的默认页面都是版本设置页，导致此卡顿的影响尤为明显。

本 PR 将高级设置分拆至单独页面中，仅在需要的时候初始化，从而缓解卡顿的问题。