### PR TITLE
Bump dependencies

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -4,16 +4,13 @@ plugins {
 
 dependencies {
     api("org.glavo:simple-png-javafx:0.3.0")
-    api("com.google.code.gson:gson:2.8.1")
+    api("com.google.code.gson:gson:2.10.1")
     api("com.moandjiezana.toml:toml4j:0.7.2")
-    api("org.tukaani:xz:1.8")
-    api("org.hildan.fxgson:fx-gson:3.1.0") {
-        exclude(group = "org.jetbrains", module = "annotations")
-    }
+    api("org.tukaani:xz:1.9")
+    api("org.hildan.fxgson:fx-gson:5.0.0")
     api("org.jenkins-ci:constant-pool-scanner:1.2")
-    api("com.github.steveice10:opennbt:1.1")
-    api("com.nqzero:permit-reflect:0.3")
+    api("com.github.steveice10:opennbt:1.4")
     api("org.nanohttpd:nanohttpd:2.3.1")
-    api("org.apache.commons:commons-compress:1.21")
-    compileOnlyApi("org.jetbrains:annotations:16.0.3")
+    api("org.apache.commons:commons-compress:1.22")
+    compileOnlyApi("org.jetbrains:annotations:24.0.0")
 }


### PR DESCRIPTION
已经在一个月前在下游的友一中进行了更新，没有不良反馈。