### PR TITLE
Bump dependencies

### DIFF
--- a/HMCLCore/build.gradle.kts
+++ b/HMCLCore/build.gradle.kts
@@ -9,8 +9,8 @@ dependencies {
     api("org.tukaani:xz:1.9")
     api("org.hildan.fxgson:fx-gson:5.0.0")
     api("org.jenkins-ci:constant-pool-scanner:1.2")
-    api("com.github.steveice10:opennbt:1.4")
+    api("com.github.steveice10:opennbt:1.5")
     api("org.nanohttpd:nanohttpd:2.3.1")
-    api("org.apache.commons:commons-compress:1.22")
-    compileOnlyApi("org.jetbrains:annotations:24.0.0")
+    api("org.apache.commons:commons-compress:1.23.0")
+    compileOnlyApi("org.jetbrains:annotations:24.0.1")
 }


### PR DESCRIPTION
* 将 OpenNBT 更新至 1.5，修复了一些资源泄露问题；
* 将 commons-compress 更新至 1.23.0，解决了无法打开头部带有其他内容的 zip 文件的问题；
* 将 JetBrains Annotations 更新至 24.0.1。