### PR TITLE
优化 VersionNumber

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/versioning/VersionNumber.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/versioning/VersionNumber.java
@@ -89,7 +89,7 @@ public final class VersionNumber implements Comparable<VersionNumber> {
 
         boolean isNull();
 
-        void appendTo(StringBuilder buf);
+        void appendTo(StringBuilder buffer);
     }
 
     private static final class LongItem implements Item {
@@ -133,8 +133,8 @@ public final class VersionNumber implements Comparable<VersionNumber> {
         }
 
         @Override
-        public void appendTo(StringBuilder buf) {
-            buf.append(value);
+        public void appendTo(StringBuilder buffer) {
+            buffer.append(value);
         }
 
         public String toString() {
@@ -186,8 +186,8 @@ public final class VersionNumber implements Comparable<VersionNumber> {
         }
 
         @Override
-        public void appendTo(StringBuilder buf) {
-            buf.append(value);
+        public void appendTo(StringBuilder buffer) {
+            buffer.append(value);
         }
 
         public String toString() {
@@ -235,8 +235,8 @@ public final class VersionNumber implements Comparable<VersionNumber> {
         }
 
         @Override
-        public void appendTo(StringBuilder buf) {
-            buf.append(value);
+        public void appendTo(StringBuilder buffer) {
+            buffer.append(value);
         }
 
         public String toString() {
@@ -320,19 +320,19 @@ public final class VersionNumber implements Comparable<VersionNumber> {
         }
 
         @Override
-        public void appendTo(StringBuilder buf) {
+        public void appendTo(StringBuilder buffer) {
             if (separator != null) {
-                buf.append((char) separator);
+                buffer.append((char) separator);
             }
 
-            final int initLength = buf.length();
+            final int initLength = buffer.length();
 
             for (Item item : this) {
-                if (buf.length() > initLength) {
+                if (buffer.length() > initLength) {
                     if (!(item instanceof ListItem))
-                        buf.append('.');
+                        buffer.append('.');
                 }
-                item.appendTo(buf);
+                item.appendTo(buffer);
             }
         }
 

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
@@ -19,105 +19,124 @@ package org.jackhuang.hmcl.util.versioning;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
+import java.util.function.Supplier;
 
+import static org.jackhuang.hmcl.util.versioning.VersionNumber.isIntVersionNumber;
+import static org.jackhuang.hmcl.util.versioning.VersionNumber.normalize;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class VersionNumberTest {
 
     @Test
     public void testCanonical() {
-        VersionNumber u, v;
+        assertEquals("3.2", normalize("3.2.0.0"));
+        assertEquals("3.2-5", normalize("3.2.0.0-5"));
+        assertEquals("3.2", normalize("3.2.0.0-0"));
+        assertEquals("3.2", normalize("3.2--------"));
+        assertEquals("3.2", normalize("3.0002"));
+        assertEquals("1.7.2$%%^@&snapshot-3.1.1", normalize("1.7.2$%%^@&snapshot-3.1.1"));
+        assertEquals("1.99999999999999999999", normalize("1.99999999999999999999"));
+        assertEquals("1.99999999999999999999", normalize("1.0099999999999999999999"));
+        assertEquals("1.99999999999999999999", normalize("1.99999999999999999999.0"));
+        assertEquals("1.99999999999999999999", normalize("1.99999999999999999999--------"));
+    }
 
-        v = VersionNumber.asVersion("3.2.0.0");
-        assertEquals("3.2", v.getCanonical());
+    @Test
+    public void testIsIntVersion() {
+        assertFalse(isIntVersionNumber(""));
+        assertFalse(isIntVersionNumber(" "));
+        assertFalse(isIntVersionNumber("."));
+        assertFalse(isIntVersionNumber("1."));
+        assertFalse(isIntVersionNumber(".1"));
+        assertFalse(isIntVersionNumber(".1."));
+        assertFalse(isIntVersionNumber("1..8"));
+        assertFalse(isIntVersionNumber("1.8."));
+        assertFalse(isIntVersionNumber(".1.8"));
+        assertFalse(isIntVersionNumber("1.7.10forge1614_FTBInfinity"));
+        assertFalse(isIntVersionNumber("3.2-5"));
+        assertFalse(isIntVersionNumber("1.9999999999"));
 
-        v = VersionNumber.asVersion("3.2.0.0-5");
-        assertEquals("3.2-5", v.getCanonical());
+        assertTrue(isIntVersionNumber("0.1"));
+        assertTrue(isIntVersionNumber("0.1.0"));
+        assertTrue(isIntVersionNumber("1.8"));
+        assertTrue(isIntVersionNumber("1.12.2"));
+        assertTrue(isIntVersionNumber("1.13.1"));
+        assertTrue(isIntVersionNumber("1.999999999"));
+    }
 
-        v = VersionNumber.asVersion("3.2.0.0-0");
-        assertEquals("3.2", v.getCanonical());
+    private static void assertLessThan(String s1, String s2) {
+        Supplier<String> messageSupplier = () -> String.format("%s should be less than %s", s1, s2);
 
-        v = VersionNumber.asVersion("3.2--------");
-        assertEquals("3.2", v.getCanonical());
+        VersionNumber v1 = VersionNumber.asVersion(s1);
+        VersionNumber v2 = VersionNumber.asVersion(s2);
 
-        v = VersionNumber.asVersion("1.7.2$%%^@&snapshot-3.1.1");
-        assertEquals("1.7.2$%%^@&snapshot-3.1.1", v.getCanonical());
+        assertTrue(v1.compareTo(v2) < 0, messageSupplier);
+        assertTrue(v2.compareTo(v1) > 0, messageSupplier);
     }
 
     @Test
     public void testComparator() {
-        VersionNumber u, v;
-
-        u = VersionNumber.asVersion("1.7.10forge1614_FTBInfinity");
-        v = VersionNumber.asVersion("1.12.2");
-        assertTrue(u.compareTo(v) < 0);
-
-        u = VersionNumber.asVersion("1.8.0_51");
-        v = VersionNumber.asVersion("1.8.0.51");
-        assertTrue(u.compareTo(v) < 0);
-
-        u = VersionNumber.asVersion("1.8.0_151");
-        v = VersionNumber.asVersion("1.8.0_77");
-        assertTrue(u.compareTo(v) > 0);
-
-        u = VersionNumber.asVersion("1.6.0_22");
-        v = VersionNumber.asVersion("1.8.0_11");
-        assertTrue(u.compareTo(v) < 0);
-
-        u = VersionNumber.asVersion("1.7.0_22");
-        v = VersionNumber.asVersion("1.7.99");
-        assertTrue(u.compareTo(v) < 0);
-
-        u = VersionNumber.asVersion("1.12.2-14.23.5.2760");
-        v = VersionNumber.asVersion("1.12.2-14.23.4.2739");
-        assertTrue(u.compareTo(v) > 0);
+        assertLessThan("1.7.10forge1614_FTBInfinity", "1.12.2");
+        assertLessThan("1.8.0_51", "1.8.0.51");
+        assertLessThan("1.8.0_77", "1.8.0_151");
+        assertLessThan("1.6.0_22", "1.8.0_11");
+        assertLessThan("1.7.0_22", "1.7.99");
+        assertLessThan("1.12.2-14.23.4.2739", "1.12.2-14.23.5.2760");
+        assertLessThan("1.9", "1.99999999999999999999");
     }
 
     @Test
     public void testSorting() {
-        List<String> input = Arrays.asList(
-                "1.10",
-                "1.10.2",
-                "1.10.2-All the Mods",
-                "1.10.2-AOE",
-                "1.10.2-AOE-1.1.5",
-                "1.10.2-forge2511-Age_of_Progression",
-                "1.10.2-forge2511-AOE-1.1.2",
-                "1.10.2-forge2511-ATM-E",
-                "1.10.2-forge2511-simple_life_2",
-                "1.10.2-forge2511_bxztest",
-                "1.10.2-forge2511_Farming_Valley",
-                "1.10.2-forge2511中文",
-                "1.10.2-FTB_Beyond",
-                "1.10.2-LiteLoader1.10.2",
-                "1.12.2",
-                "1.12.2_Modern_Skyblock-3.4.2",
-                "1.13.1",
+        final Comparator<String> comparator = VersionNumber.VERSION_COMPARATOR.thenComparing(String::compareTo);
+        final List<String> input = Collections.unmodifiableList(Arrays.asList(
                 "1.6.4",
                 "1.6.4-Forge9.11.1.1345",
                 "1.7.10",
-                "1.7.10-1614",
-                "1.7.10-1614-test",
+                "1.7.10Agrarian_Skies_2",
                 "1.7.10-F1614-L",
                 "1.7.10-FL1614_04",
                 "1.7.10-Forge10.13.4.1614-1.7.10",
                 "1.7.10-Forge1614",
-                "1.7.10-Forge1614.1",
-                "1.7.10Agrarian_Skies_2",
-                "1.7.10forge1614test",
-                "1.7.10forge1614_ATlauncher",
-                "1.7.10forge1614_FTBInfinity",
                 "1.7.10Forge1614_FTBInfinity-2.6.0",
                 "1.7.10Forge1614_FTBInfinity-3.0.1",
+                "1.7.10-Forge1614.1",
+                "1.7.10forge1614_ATlauncher",
+                "1.7.10forge1614_FTBInfinity",
                 "1.7.10forge1614_FTBInfinity_server",
+                "1.7.10forge1614test",
+                "1.7.10-1614",
+                "1.7.10-1614-test",
                 "1.8",
                 "1.8-forge1577",
                 "1.8.9",
                 "1.8.9-forge1902",
-                "1.9");
-        input.sort(Comparator.comparing(VersionNumber::asVersion));
+                "1.9",
+                "1.10",
+                "1.10.2",
+                "1.10.2-AOE",
+                "1.10.2-AOE-1.1.5",
+                "1.10.2-All the Mods",
+                "1.10.2-FTB_Beyond",
+                "1.10.2-LiteLoader1.10.2",
+                "1.10.2-forge2511-AOE-1.1.2",
+                "1.10.2-forge2511-ATM-E",
+                "1.10.2-forge2511-Age_of_Progression",
+                "1.10.2-forge2511_Farming_Valley",
+                "1.10.2-forge2511_bxztest",
+                "1.10.2-forge2511-simple_life_2",
+                "1.10.2-forge2511中文",
+                "1.12.2",
+                "1.12.2_Modern_Skyblock-3.4.2",
+                "1.13.1",
+                "1.99999999999999999999"));
+
+        List<String> output = new ArrayList<>(input);
+        output.sort(comparator);
+        assertIterableEquals(input, output);
+
+        Collections.shuffle(output, new Random(0));
+        output.sort(VersionNumber.VERSION_COMPARATOR.thenComparing(String::compareTo));
+        assertIterableEquals(input, output);
     }
 }

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
@@ -57,12 +57,15 @@ public class VersionNumberTest {
         assertFalse(isIntVersionNumber("3.2-5"));
         assertFalse(isIntVersionNumber("1.9999999999"));
 
+        assertTrue(isIntVersionNumber("0"));
+        assertTrue(isIntVersionNumber("1"));
         assertTrue(isIntVersionNumber("0.1"));
         assertTrue(isIntVersionNumber("0.1.0"));
         assertTrue(isIntVersionNumber("1.8"));
         assertTrue(isIntVersionNumber("1.12.2"));
         assertTrue(isIntVersionNumber("1.13.1"));
         assertTrue(isIntVersionNumber("1.999999999"));
+        assertTrue(isIntVersionNumber("999999999.0"));
     }
 
     private static void assertLessThan(String s1, String s2) {
@@ -93,6 +96,8 @@ public class VersionNumberTest {
     public void testSorting() {
         final Comparator<String> comparator = VersionNumber.VERSION_COMPARATOR.thenComparing(String::compareTo);
         final List<String> input = Collections.unmodifiableList(Arrays.asList(
+                "0",
+                "0.10.0",
                 "1.6.4",
                 "1.6.4-Forge9.11.1.1345",
                 "1.7.10",
@@ -132,14 +137,17 @@ public class VersionNumberTest {
                 "1.12.2",
                 "1.12.2_Modern_Skyblock-3.4.2",
                 "1.13.1",
-                "1.99999999999999999999"));
+                "1.99999999999999999999",
+                "2",
+                "2.0",
+                "2.1"));
 
         List<String> output = new ArrayList<>(input);
         output.sort(comparator);
         assertIterableEquals(input, output);
 
         Collections.shuffle(output, new Random(0));
-        output.sort(VersionNumber.VERSION_COMPARATOR.thenComparing(String::compareTo));
+        output.sort(comparator);
         assertIterableEquals(input, output);
     }
 }

--- a/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
+++ b/HMCLCore/src/test/java/org/jackhuang/hmcl/util/versioning/VersionNumberTest.java
@@ -84,6 +84,9 @@ public class VersionNumberTest {
         assertLessThan("1.7.0_22", "1.7.99");
         assertLessThan("1.12.2-14.23.4.2739", "1.12.2-14.23.5.2760");
         assertLessThan("1.9", "1.99999999999999999999");
+        assertLessThan("1.99999999999999999999", "1.199999999999999999999");
+        assertLessThan("1.99999999999999999999", "2");
+        assertLessThan("1.99999999999999999999", "2.0");
     }
 
     @Test


### PR DESCRIPTION
JMH 测试结果表明，该 PR 使 `asVersion` 的性能提升了 50%~130%，纯数字的 `VersionNumber` 比较的性能提升了约 70%，`isIntVersion` 的性能提升了 70%~620%。


<details><summary>测试源码</summary>

```java
@Warmup(iterations = 5, time = 3)
@Measurement(iterations = 5, time = 3)
@Fork(value = 1, jvmArgsAppend = {"-XX:+UseG1GC", "-Xms8g", "-Xmx8g"})
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Benchmark)
public class VersionNumberBenchmark {

    @Benchmark
    public VersionNumber asVersion1() {
        return VersionNumber.asVersion("1.8");
    }

    @Benchmark
    public VersionNumber asVersion2() {
        return VersionNumber.asVersion("1.7.10forge1614_FTBInfinity");
    }

    private static final VersionNumber v1 = VersionNumber.asVersion("1.16.3");
    private static final VersionNumber v2 = VersionNumber.asVersion("1.16.5");

    @Benchmark
    public int compareVersion() {
        return v1.compareTo(v2);
    }

    @Benchmark
    public boolean isIntVersion1() {
        return VersionNumber.isIntVersionNumber("1.16.5");
    }

    @Benchmark
    public boolean isIntVersion2() {
        return VersionNumber.isIntVersionNumber("1.16.5-forge");
    }
}
```

</p>
</details>