### PR TITLE
检测 macOS 上的 App Translocation

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -87,8 +87,8 @@ public final class Launcher extends Application {
             }
 
             // https://lapcatsoftware.com/articles/app-translocation.html
-            if (ConfigHolder.isNewlyCreated()
-                    && OperatingSystem.CURRENT_OS == OperatingSystem.OSX
+            if (OperatingSystem.CURRENT_OS == OperatingSystem.OSX
+                    && ConfigHolder.isNewlyCreated()
                     && System.getProperty("user.dir").startsWith("/private/var/folders/")) {
 
                 if (showAlert(AlertType.WARNING, i18n("fatal.mac_app_translocation"), ButtonType.YES, ButtonType.NO) == ButtonType.NO) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -20,6 +20,7 @@ package org.jackhuang.hmcl;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.DataFormat;
@@ -85,12 +86,20 @@ public final class Launcher extends Application {
                 Main.showErrorAndExit(i18n("fatal.config_loading_failure", ConfigHolder.configLocation().getParent()));
             }
 
-            checkConfigInTempDir();
+            // https://lapcatsoftware.com/articles/app-translocation.html
+            if (ConfigHolder.isNewlyCreated()
+                    && OperatingSystem.CURRENT_OS == OperatingSystem.OSX
+                    && System.getProperty("user.dir").startsWith("/private/var/folders/")) {
+
+                if (showAlert(AlertType.WARNING, i18n("fatal.mac_app_translocation"), ButtonType.YES, ButtonType.NO) == ButtonType.NO) {
+                    System.exit(0);
+                }
+            } else {
+                checkConfigInTempDir();
+            }
+
             if (ConfigHolder.isOwnerChanged()) {
-                ButtonType res = new Alert(Alert.AlertType.WARNING, i18n("fatal.config_change_owner_root"), ButtonType.YES, ButtonType.NO)
-                        .showAndWait()
-                        .orElse(null);
-                if (res == ButtonType.NO)
+                if (showAlert(AlertType.WARNING, i18n("fatal.config_change_owner_root"), ButtonType.YES, ButtonType.NO) == ButtonType.NO)
                     return;
             }
 
@@ -112,6 +121,10 @@ public final class Launcher extends Application {
         } catch (Throwable e) {
             CRASH_REPORTER.uncaughtException(Thread.currentThread(), e);
         }
+    }
+
+    private static ButtonType showAlert(AlertType alertType, String contentText, ButtonType... buttons) {
+        return new Alert(alertType, contentText, buttons).showAndWait().orElse(null);
     }
 
     private static boolean isConfigInTempDir() {
@@ -152,13 +165,9 @@ public final class Launcher extends Application {
     }
 
     private static void checkConfigInTempDir() {
-        if (ConfigHolder.isNewlyCreated() && isConfigInTempDir()) {
-            ButtonType res = new Alert(Alert.AlertType.WARNING, i18n("fatal.config_in_temp_dir"), ButtonType.YES, ButtonType.NO)
-                    .showAndWait()
-                    .orElse(null);
-            if (res == ButtonType.NO) {
-                System.exit(0);
-            }
+        if (ConfigHolder.isNewlyCreated() && isConfigInTempDir()
+                && showAlert(AlertType.WARNING, i18n("fatal.config_in_temp_dir"), ButtonType.YES, ButtonType.NO) == ButtonType.NO) {
+            System.exit(0);
         }
     }
 
@@ -190,10 +199,9 @@ public final class Launcher extends Application {
         String command = new CommandBuilder().add("sudo", "chown", "-R", userName).addAll(files).toString();
         ButtonType copyAndExit = new ButtonType(i18n("button.copy_and_exit"));
 
-        ButtonType res = new Alert(Alert.AlertType.ERROR, i18n("fatal.config_loading_failure.unix", owner, command), copyAndExit, ButtonType.CLOSE)
-                .showAndWait()
-                .orElse(null);
-        if (res == copyAndExit) {
+        if (showAlert(AlertType.ERROR,
+                i18n("fatal.config_loading_failure.unix", owner, command),
+                copyAndExit, ButtonType.CLOSE) == copyAndExit) {
             Clipboard.getSystemClipboard()
                     .setContent(Collections.singletonMap(DataFormat.PLAIN_TEXT, command));
         }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Launcher.java
@@ -90,10 +90,8 @@ public final class Launcher extends Application {
             if (OperatingSystem.CURRENT_OS == OperatingSystem.OSX
                     && ConfigHolder.isNewlyCreated()
                     && System.getProperty("user.dir").startsWith("/private/var/folders/")) {
-
-                if (showAlert(AlertType.WARNING, i18n("fatal.mac_app_translocation"), ButtonType.YES, ButtonType.NO) == ButtonType.NO) {
-                    System.exit(0);
-                }
+                if (showAlert(AlertType.WARNING, i18n("fatal.mac_app_translocation"), ButtonType.YES, ButtonType.NO) == ButtonType.NO)
+                    return;
             } else {
                 checkConfigInTempDir();
             }

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -360,6 +360,9 @@ fatal.config_loading_failure=Cannot load configuration files.\n\
 Please make sure that "Hello Minecraft! Launcher" has read and write access to "%s" and the files in it.
 fatal.config_loading_failure.unix=Hello Minecraft! Launcher could not load the profile because the profile was created by user %1$s.\n\
 Please start HMCL with sudo (not recommended), or execute the following command in the terminal to change the ownership of the configuration file to the current user:\n%2$s
+fatal.mac_app_translocation=Due to the security mechanism of macOS, Hello Minecraft! Launcher is quarantined by the system to the temporary folder.\n\
+Please move Hello Minecraft! Launcher to a different folder before attempting to start, otherwise your settings and game data may be lost after restarting.\n\
+Do you still want to continue?
 fatal.migration_requires_manual_reboot=Hello Minecraft! Launcher has been upgraded. Please reopen the launcher.
 fatal.apply_update_failure=We are sorry, but Hello Minecraft! Launcher is unable to update.\n\
 \n\

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -355,6 +355,7 @@ fatal.config_change_owner_root=你正在使用 root 帳戶啟動 Hello Minecraft
 fatal.config_in_temp_dir=你正在臨時資料夾中啟動 Hello Minecraft! Launcher，你的設定和遊戲數據可能會遺失，建議將 HMCL 移動至其他位置再啟動。\n是否繼續啟動？
 fatal.config_loading_failure=Hello Minecraft! Launcher 無法載入設定檔案。\n請確保 Hello Minecraft! Launcher 對 "%s" 目錄及該目錄下的檔案擁有讀寫權限。
 fatal.config_loading_failure.unix=Hello Minecraft! Launcher 無法載入設定檔案，因為設定檔案是由用戶 %1$s 創建的。\n請使用 root 帳戶啟動 HMCL (不推薦)，或在終端中執行以下命令將設定檔案的所有權變更為當前用戶: \n%2$s
+fatal.mac_app_translocation=由於 macOS 的安全機制，Hello Minecraft! Launcher 被系統隔離至臨時資料夾中。\n請將Hello Minecraft! Launcher 移動到其他資料夾後再嘗試啟動，否則你的設定和遊戲數據可能會在重啟後遺失。\n是否繼續啟動？
 fatal.migration_requires_manual_reboot=Hello Minecraft! Launcher 即將升級完成，請重新開啟 Hello Minecraft! Launcher。
 fatal.apply_update_failure=我們很抱歉 Hello Minecraft! Launcher 無法自動完成升級程式，因為出現了一些問題。\n但你依然可以從 %s 處手動下載 Hello Minecraft! Launcher 來完成升級。\n你可以訪問 https://docs.hmcl.net/help.html 網頁進行迴響。
 fatal.samba=如果您正在通過 Samba 共亯的資料夾中運行 Hello Minecraft! Launcher，啟動器可能無法正常工作，請嘗試更新您的 Java 或在本地資料夾內運行 HMCL。

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -355,6 +355,7 @@ fatal.config_change_owner_root=你正在使用 root 账户启动 Hello Minecraft
 fatal.config_in_temp_dir=你正在临时文件夹中启动 Hello Minecraft! Launcher, 你的设置和游戏数据可能会丢失，建议将 HMCL 移动至其他位置再启动。\n是否继续启动？
 fatal.config_loading_failure=Hello Minecraft! Launcher 无法加载配置文件\n请确保 Hello Minecraft! Launcher 对 "%s" 目录及该目录下的文件拥有读写权限。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
 fatal.config_loading_failure.unix=Hello Minecraft! Launcher 无法加载配置文件，因为配置文件是由用户 %1$s 创建的。\n请使用 root 账户启动 HMCL (不推荐)，或在终端中执行以下命令将配置文件的所有权变更为当前用户:\n%2$s\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。
+fatal.mac_app_translocation=由于 macOS 的安全机制，Hello Minecraft! Launcher 被系统隔离至临时文件夹中。\n请将 Hello Minecraft! Launcher 移动到其他文件夹后再尝试启动，否则你的设置和游戏数据可能会在重启后丢失。\n是否继续启动？
 fatal.migration_requires_manual_reboot=Hello Minecraft! Launcher 即将完成升级，请重新打开 Hello Minecraft! Launcher。
 fatal.apply_update_failure=我们很抱歉 Hello Minecraft! Launcher 无法自动完成升级，因为出现了一些问题。\n但你依可以从 %s 处手动下载 Hello Minecraft! Launcher 来完成升级\n你可以访问 https://docs.hmcl.net/help.html 网页进行反馈。
 fatal.samba=如果你正在通过 Samba 共享的文件夹中运行 Hello Minecraft! Launcher，启动器可能无法正常工作。请尝试更新你的 Java 或在本地文件夹内运行 Hello Minecraft! Launcher。\n你可以访问 https://docs.hmcl.net/help.html 页面寻求帮助。


### PR DESCRIPTION
macOS 使用了 [App Translocation](https://lapcatsoftware.com/articles/app-translocation.html) 机制，可能会自动将 HMCL 移动至 `/private/var/folders` 中的临时文件夹内，导致用户关闭 HMCL 后游戏数据和设置丢失。

