### PR TITLE
Fix #2268

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameVersion.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/GameVersion.java
@@ -49,7 +49,7 @@ public final class GameVersion {
     private static Optional<String> getVersionFromJson(InputStream versionJson) {
         try {
             Map<?, ?> version = JsonUtils.fromNonNullJsonFully(versionJson, Map.class);
-            return tryCast(version.get("name"), String.class);
+            return tryCast(version.get("id"), String.class);
         } catch (IOException | JsonParseException e) {
             LOG.log(Level.WARNING, "Failed to parse version.json", e);
             return Optional.empty();


### PR DESCRIPTION
Fix #2268

问题描述：
使用HMCL导出的MCBBS格式的候选发布版本（Release Candidate）整合包无法被安装，显示为“无法从服务器获取版本1.20 Release Candidate 1”
同样的游戏实例使用Bakaxl导出的整合包可以正常安装。
推测是因为导出时生成的整合包manifest文件中，version一项填写的是1.20 Release Candidate 1，和下载服务器的1.20-rc1对不上，导致整合包无法安装。

出现问题的代码：
```java
// 来自 org.jackhuang.hmcl.game.GameVersion#getVersionFromJson
private static Optional<String> getVersionFromJson(InputStream versionJson) {
    try {
        Map<?, ?> version = JsonUtils.fromNonNullJsonFully(versionJson, Map.class);
        return tryCast(version.get("name"), String.class);
    } catch (IOException | JsonParseException e) {
        LOG.log(Level.WARNING, "Failed to parse version.json", e);
        return Optional.empty();
    }
}
```

调用栈：
```
getVersionFromJson:52, GameVersion (org.jackhuang.hmcl.game)
minecraftVersion:98, GameVersion (org.jackhuang.hmcl.game)
lambda$getGameVersion$0:149, DefaultGameRepository (org.jackhuang.hmcl.game)
apply:-1, 543574736 (org.jackhuang.hmcl.game.DefaultGameRepository$$Lambda$494)
computeIfAbsent:1705, ConcurrentHashMap (java.util.concurrent)
getGameVersion:148, DefaultGameRepository (org.jackhuang.hmcl.game)
getGameVersion:162, GameRepository (org.jackhuang.hmcl.game)
lambda$new$0:62, GameItem (org.jackhuang.hmcl.ui.versions)
get:-1, 920277670 (org.jackhuang.hmcl.ui.versions.GameItem$$Lambda$486)
run:1700, CompletableFuture$AsyncSupply (java.util.concurrent)
runWorker:1128, ThreadPoolExecutor (java.util.concurrent)
run:628, ThreadPoolExecutor$Worker (java.util.concurrent)
run:829, Thread (java.lang)
```

局部变量：
![image](https://github.com/huanghongxun/HMCL/assets/88144530/1c947114-8de7-453b-9db2-3027de13eae0)

解释：
对于 Minecraft 1.18.1，其 version.jar!/version.json 如下：
```json
{
    "id": "1.18.1",
    "name": "1.18.1",
    "release_target": "1.18.1",
    "world_version": 2865,
    "series_id": "main",
    "protocol_version": 757,
    "pack_version": {
        "resource": 8,
        "data": 8
    },
    "build_time": "2021-12-10T08:21:01+00:00",
    "java_component": "java-runtime-beta",
    "java_version": 17,
    "stable": true
}
```
但对于 Minecraft 1.20 Release Candidate 1，其 version.jar!/version.json 如下：
```json
{
    "id": "1.20.1-rc1",
    "name": "1.20.1 Release Candidate 1",
    "world_version": 3464,
    "series_id": "main",
    "protocol_version": 1073741966,
    "pack_version": {
        "resource": 15,
        "data": 15
    },
    "build_time": "2023-06-09T14:13:26+00:00",
    "java_component": "java-runtime-gamma",
    "java_version": 17,
    "stable": false
}
```
显然，两者差异主要在 $.name，对于 1.18.1，\$root.id 与 \$root.name 一致；但对于 1.20-RC1，\$root.id 与 \$root.name 不一致。这就导致在初始化 HMCLGameRespository 的时候就已经出现错误。当 `org.jackhuang.hmcl.mod.mcbbs.McbbsModpackExportTask#execute` 运行到 `String gameVersion = repository.getGameVersion(version).orElseThrow(() -> new IOException("Cannot parse the version of " + version));` 时，自然也就无法正常获取游戏版本

修复方法：
将上述代码中
`return tryCast(version.get("name"), String.class);`
一行更改为
`return tryCast(version.get("id"), String.class);`

修复完毕