### PR TITLE
Fix #1750 Identify whether a file is a mod or a resourcepack when downloading modpacks.

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadAndProcessTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FileDownloadAndProcessTask.java
@@ -1,0 +1,51 @@
+package org.jackhuang.hmcl.task;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+public class FileDownloadAndProcessTask extends FileDownloadTask {
+    @FunctionalInterface
+    public interface FileProcessor {
+        void process(File file) throws IOException;
+    }
+
+    private final FileProcessor processor;
+
+    public FileDownloadAndProcessTask(URL url, File file, FileProcessor processer) {
+        super(url, file);
+        this.processor = processer;
+    }
+
+    public FileDownloadAndProcessTask(URL url, File file, IntegrityCheck integrityCheck, FileProcessor processer) {
+        super(url, file, integrityCheck);
+        this.processor = processer;
+    }
+
+    public FileDownloadAndProcessTask(URL url, File file, IntegrityCheck integrityCheck, int retry, FileProcessor processer) {
+        super(url, file, integrityCheck, retry);
+        this.processor = processer;
+    }
+
+    public FileDownloadAndProcessTask(List<URL> urls, File file, FileProcessor processer) {
+        super(urls, file);
+        this.processor = processer;
+    }
+
+    public FileDownloadAndProcessTask(List<URL> urls, File file, IntegrityCheck integrityCheck, FileProcessor processer) {
+        super(urls, file, integrityCheck);
+        this.processor = processer;
+    }
+
+    public FileDownloadAndProcessTask(List<URL> urls, File file, IntegrityCheck integrityCheck, int retry, FileProcessor processer) {
+        super(urls, file, integrityCheck, retry);
+        this.processor = processer;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        super.execute();
+        this.processor.process(this.getFile());
+    }
+}


### PR DESCRIPTION
Fix #1750 Fix #2441
将以 .zip 结尾的或内部没有 META-INF/MANIFEST.MF 的文件移动到 resourcepacks 下
![image](https://github.com/huanghongxun/HMCL/assets/88144530/c5a511e1-a5e9-4ff0-8a4a-f8c355c21f37)

```
FileDownloadTask task = new FileDownloadAndProcessTask(file.getUrl(), modManager.getSimpleModPath(file.getFileName()).toFile(), downloadedFile -> {
    boolean shouldMove = downloadedFile.getName().endsWith(".zip");
    if (!shouldMove) {
        try (JarFile jarFile = new JarFile(downloadedFile)) {
            shouldMove = jarFile.getEntry("META-INF/MANIFEST.MF") == null;
        }
    }
    if (shouldMove) {
        Path toPath = this.repository.getVersionRoot(this.version).toPath().resolve("resourcepacks").resolve(downloadedFile.getName()).toAbsolutePath();
        if (!toPath.getParent().toFile().exists()) {
            toPath.getParent().toFile().mkdirs();
        }
        Files.move(downloadedFile.toPath(), toPath);
    }
});
```