### PR TITLE
为模组/整合包版本列表添加ModLoaderType标签

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -406,7 +406,10 @@ public class DownloadPage extends Control implements DecoratorPage {
                     break;
             }
 
-            content.getTags().addAll(dataItem.getLoaders().stream().filter(loader -> loader != ModLoaderType.UNKNOWN).map(Enum::name).collect(Collectors.toList()));
+            content.getTags().addAll(dataItem.getLoaders().stream()
+                    .filter(loader -> loader != ModLoaderType.UNKNOWN)
+                    .map(loader -> i18n("install.installer." + loader.name().toLowerCase()))
+                    .collect(Collectors.toList()));
 
             // Workaround for https://github.com/huanghongxun/HMCL/issues/2129
             this.setMinHeight(50);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/DownloadPage.java
@@ -35,6 +35,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.*;
 import javafx.stage.FileChooser;
+import org.jackhuang.hmcl.mod.ModLoaderType;
 import org.jackhuang.hmcl.mod.ModManager;
 import org.jackhuang.hmcl.mod.RemoteMod;
 import org.jackhuang.hmcl.mod.RemoteModRepository;
@@ -404,6 +405,8 @@ public class DownloadPage extends Control implements DecoratorPage {
                     content.getTags().add(i18n("version.game.snapshot"));
                     break;
             }
+
+            content.getTags().addAll(dataItem.getLoaders().stream().filter(loader -> loader != ModLoaderType.UNKNOWN).map(Enum::name).collect(Collectors.toList()));
 
             // Workaround for https://github.com/huanghongxun/HMCL/issues/2129
             this.setMinHeight(50);

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -830,6 +830,7 @@ modrinth.category.velocity=Velocity
 modrinth.category.waterfall=Waterfall
 modrinth.category.worldgen=Worldgen
 modrinth.category.datapack=Datapack
+modrinth.category.folia=Folia
 
 mods=Mods
 mods.add=Add Mods

--- a/HMCL/src/main/resources/assets/lang/I18N_es.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_es.properties
@@ -771,6 +771,7 @@ modrinth.category.technology=Tecnología
 modrinth.category.utility=Utilidad
 modrinth.category.worldgen=Generación de mundos
 modrinth.category.datapack=Datapack
+modrinth.category.folia=Folia
 
 mods=Mods
 mods.add=Añadir mods

--- a/HMCL/src/main/resources/assets/lang/I18N_ja.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ja.properties
@@ -609,6 +609,7 @@ modrinth.category.technology=テクノロジー
 modrinth.category.utility=ユーティリティ
 modrinth.category.worldgen=Worldgen
 modrinth.category.datapack=Datapack
+modrinth.category.folia=Folia
 
 mods=Mods
 mods.add=modを追加

--- a/HMCL/src/main/resources/assets/lang/I18N_ru.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_ru.properties
@@ -614,6 +614,7 @@ modrinth.category.technology=Технология
 modrinth.category.utility=Утилиты
 modrinth.category.worldgen=Генерация мира
 modrinth.category.datapack=Datapack
+modrinth.category.folia=Folia
 
 mods=Моды
 mods.add=Установить моды

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -706,6 +706,7 @@ modrinth.category.velocity=Velocity
 modrinth.category.waterfall=Waterfall
 modrinth.category.worldgen=世界生成
 modrinth.category.datapack=數據包
+modrinth.category.folia=Folia
 
 mods=模組
 mods.add=新增模組

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -704,6 +704,7 @@ modrinth.category.velocity=Velocity
 modrinth.category.waterfall=Waterfall
 modrinth.category.worldgen=世界生成
 modrinth.category.datapack=数据包
+modrinth.category.folia=Folia
 
 mods=模组
 mods.add=添加模组

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModLoaderType.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/ModLoaderType.java
@@ -21,6 +21,7 @@ public enum ModLoaderType {
     UNKNOWN,
     FORGE,
     FABRIC,
+    QUILT,
     LITE_LOADER,
     PACK
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -562,6 +562,8 @@ public class CurseAddon implements RemoteMod.IMod {
                 modLoaderType = ModLoaderType.FORGE;
             } else if (gameVersions.contains("Fabric")) {
                 modLoaderType = ModLoaderType.FABRIC;
+            } else if (gameVersions.contains("Quilt")) {
+                modLoaderType = ModLoaderType.QUILT;
             } else {
                 modLoaderType = ModLoaderType.UNKNOWN;
             }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -557,17 +557,6 @@ public class CurseAddon implements RemoteMod.IMod {
                     break;
             }
 
-            ModLoaderType modLoaderType;
-            if (gameVersions.contains("Forge")) {
-                modLoaderType = ModLoaderType.FORGE;
-            } else if (gameVersions.contains("Fabric")) {
-                modLoaderType = ModLoaderType.FABRIC;
-            } else if (gameVersions.contains("Quilt")) {
-                modLoaderType = ModLoaderType.QUILT;
-            } else {
-                modLoaderType = ModLoaderType.UNKNOWN;
-            }
-
             return new RemoteMod.Version(
                     this,
                     Integer.toString(modId),
@@ -579,7 +568,12 @@ public class CurseAddon implements RemoteMod.IMod {
                     new RemoteMod.File(Collections.emptyMap(), getDownloadUrl(), getFileName()),
                     Collections.emptyList(),
                     gameVersions.stream().filter(ver -> ver.startsWith("1.") || ver.contains("w")).collect(Collectors.toList()),
-                    Collections.singletonList(modLoaderType)
+                    gameVersions.stream().flatMap(version -> {
+                        if ("fabric".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FABRIC);
+                        else if ("forge".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FORGE);
+                        else if ("quilt".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.QUILT);
+                        else return Stream.empty();
+                    }).collect(Collectors.toList())
             );
         }
     }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -497,6 +497,7 @@ public final class ModrinthRemoteModRepository implements RemoteModRepository {
                     loaders.stream().flatMap(loader -> {
                         if ("fabric".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.FABRIC);
                         else if ("forge".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.FORGE);
+                        else if ("quilt".equalsIgnoreCase(loader)) return Stream.of(ModLoaderType.QUILT);
                         else return Stream.empty();
                     }).collect(Collectors.toList())
             ));


### PR DESCRIPTION
- 有些模组文件的DisplayName和FileName都没注明加载器类型，需要跳转到网页才能看到。添加标签后一目了然。
 ![image](https://github.com/huanghongxun/HMCL/assets/67496378/2aa019ce-3729-4442-a335-37804f550b3d)

- 添加了Modrinth分类“[Folia](https://github.com/PaperMC/Folia)”的翻译键。
![image](https://github.com/huanghongxun/HMCL/assets/67496378/930229e4-2c8d-4a21-82bc-65c7022ba136)
