### PR TITLE
添加 Curse RemoteMod.Version 对多个 ModLoaderType 的支持

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -557,17 +557,6 @@ public class CurseAddon implements RemoteMod.IMod {
                     break;
             }
 
-            ModLoaderType modLoaderType;
-            if (gameVersions.contains("Forge")) {
-                modLoaderType = ModLoaderType.FORGE;
-            } else if (gameVersions.contains("Fabric")) {
-                modLoaderType = ModLoaderType.FABRIC;
-            } else if (gameVersions.contains("Quilt")) {
-                modLoaderType = ModLoaderType.QUILT;
-            } else {
-                modLoaderType = ModLoaderType.UNKNOWN;
-            }
-
             return new RemoteMod.Version(
                     this,
                     Integer.toString(modId),
@@ -579,7 +568,12 @@ public class CurseAddon implements RemoteMod.IMod {
                     new RemoteMod.File(Collections.emptyMap(), getDownloadUrl(), getFileName()),
                     Collections.emptyList(),
                     gameVersions.stream().filter(ver -> ver.startsWith("1.") || ver.contains("w")).collect(Collectors.toList()),
-                    Collections.singletonList(modLoaderType)
+                    gameVersions.stream().flatMap(version -> {
+                        if ("fabric".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FABRIC);
+                        else if ("forge".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FORGE);
+                        else if ("quilt".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.QUILT);
+                        else return Stream.empty();
+                    }).collect(Collectors.toList())
             );
         }
     }


### PR DESCRIPTION
使 CurseForge 源的 ModItem 能够渲染多个 ModLoader
![image](https://github.com/huanghongxun/HMCL/assets/67496378/ae71f2a1-16a5-46e8-9b65-0a3d87f11e8f)

同时与 Modrinth 源的代码保持一致
https://github.com/huanghongxun/HMCL/blob/126a6dbbed4df0f51aeb32dbfcbf6570d54b139b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java#L497C1-L502C52