### PR TITLE
fix yggdrasil login

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/AuthInfo.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/AuthInfo.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 @Immutable
 public class AuthInfo implements AutoCloseable {
     public static final String USER_TYPE_MSA = "msa";
-    public static final String USER_TYPE_MOJANG = "mojang";
+    public static final String USER_TYPE_MOJANG = "Mojang";
     public static final String USER_TYPE_LEGACY = "legacy";
 
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilSession.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/yggdrasil/YggdrasilSession.java
@@ -105,7 +105,7 @@ public class YggdrasilSession {
         if (selectedProfile == null)
             throw new IllegalStateException("No character is selected");
 
-        return new AuthInfo(selectedProfile.getName(), selectedProfile.getId(), accessToken, AuthInfo.USER_TYPE_MSA,
+        return new AuthInfo(selectedProfile.getName(), selectedProfile.getId(), accessToken, AuthInfo.USER_TYPE_MOJANG,
                 Optional.ofNullable(userProperties)
                         .map(properties -> properties.entrySet().stream()
                                 .collect(Collectors.toMap(Map.Entry::getKey,


### PR DESCRIPTION
进行第三方登录时候，若--userType为msa会导致出现“无效的个人信息公钥签名”的情况，只有是"Mojang"时才能正常进入服务器