### PR TITLE
Support #1775 Enable HMCL to download resource packs from Modrinth.

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/download/DownloadPage.java
@@ -89,7 +89,7 @@ public class DownloadPage extends DecoratorAnimatedPage implements DecoratorPage
             return page;
         }));
         modTab.setNodeSupplier(loadVersionFor(() -> new ModDownloadListPage((profile, version, file) -> download(profile, version, file, "mods"), true)));
-        resourcePackTab.setNodeSupplier(loadVersionFor(() -> new DownloadListPage(CurseForgeRemoteModRepository.RESOURCE_PACKS, (profile, version, file) -> download(profile, version, file, "resourcepacks"), true)));
+        resourcePackTab.setNodeSupplier(loadVersionFor(() -> new ResourcePackDownloadListPage((profile, version, file) -> download(profile, version, file, "resourcepacks"), true)));
         customizationTab.setNodeSupplier(loadVersionFor(() -> new DownloadListPage(CurseForgeRemoteModRepository.CUSTOMIZATIONS)));
         worldTab.setNodeSupplier(loadVersionFor(() -> new DownloadListPage(CurseForgeRemoteModRepository.WORLDS)));
         tab = new TabHeader(newGameTab, modpackTab, modTab, resourcePackTab, worldTab);

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcePackDownloadListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ResourcePackDownloadListPage.java
@@ -1,0 +1,75 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.ui.versions;
+
+import org.jackhuang.hmcl.game.LocalizedRemoteModRepository;
+import org.jackhuang.hmcl.mod.RemoteModRepository;
+import org.jackhuang.hmcl.mod.curse.CurseForgeRemoteModRepository;
+import org.jackhuang.hmcl.mod.modrinth.ModrinthRemoteModRepository;
+
+import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
+
+public class ResourcePackDownloadListPage extends DownloadListPage {
+    public ResourcePackDownloadListPage(DownloadPage.DownloadCallback callback, boolean versionSelection) {
+        super(null, callback, versionSelection);
+
+        repository = new Repository();
+
+        supportChinese.set(true);
+        downloadSources.get().setAll("mods.curseforge", "mods.modrinth");
+        if (CurseForgeRemoteModRepository.isAvailable())
+            downloadSource.set("mods.curseforge");
+        else
+            downloadSource.set("mods.modrinth");
+    }
+
+    private class Repository extends LocalizedRemoteModRepository {
+
+        @Override
+        protected RemoteModRepository getBackedRemoteModRepository() {
+            if ("mods.modrinth".equals(downloadSource.get())) {
+                return ModrinthRemoteModRepository.RESOURCE_PACKS;
+            } else {
+                return CurseForgeRemoteModRepository.RESOURCE_PACKS;
+            }
+        }
+
+        @Override
+        public Type getType() {
+            return Type.MOD;
+        }
+    }
+
+    @Override
+    protected String getLocalizedCategory(String category) {
+        if ("mods.modrinth".equals(downloadSource.get())) {
+            return i18n("modrinth.category." + category);
+        } else {
+            return i18n("curse.category." + category);
+        }
+    }
+
+    @Override
+    protected String getLocalizedOfficialPage() {
+        if ("mods.modrinth".equals(downloadSource.get())) {
+            return i18n("mods.modrinth");
+        } else {
+            return i18n("mods.curseforge");
+        }
+    }
+}

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/modrinth/ModrinthRemoteModRepository.java
@@ -42,6 +42,7 @@ import static org.jackhuang.hmcl.util.Pair.pair;
 public final class ModrinthRemoteModRepository implements RemoteModRepository {
     public static final ModrinthRemoteModRepository MODS = new ModrinthRemoteModRepository("mod");
     public static final ModrinthRemoteModRepository MODPACKS = new ModrinthRemoteModRepository("modpack");
+    public static final ModrinthRemoteModRepository RESOURCE_PACKS = new ModrinthRemoteModRepository("resourcepack");
 
     private static final String PREFIX = "https://api.modrinth.com";
 


### PR DESCRIPTION
Close #1775 