### PR TITLE
Support #2365 Support viewing mods in ModListPage

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -234,4 +234,12 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
     public void setModded(boolean modded) {
         this.modded.set(modded);
     }
+
+    public Profile getProfile() {
+        return this.profile;
+    }
+
+    public String getVersionId() {
+        return this.versionId;
+    }
 }


### PR DESCRIPTION
Close #2365 

现在在 Mod 管理界面点击任何一个 Mod 右侧的 i 按钮，即可点击 Curseforge / Modrinth 按钮来根据对应远程 Mod 仓库的信息查看前置与可用版本