### PR TITLE
Support #2337 selecting the best icon when a new version is installed.

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -164,7 +164,7 @@ public class HMCLGameRepository extends DefaultGameRepository {
         Files.move(fromJson, toJson);
 
         FileUtils.writeText(toJson.toFile(), JsonUtils.GSON.toJson(fromVersion.setId(dstId)));
-        
+
         VersionSetting oldVersionSetting = getVersionSetting(srcId).clone();
         GameDirectoryType originalGameDirType = oldVersionSetting.getGameDirType();
         oldVersionSetting.setUsesGlobal(false);
@@ -273,9 +273,21 @@ public class HMCLGameRepository extends DefaultGameRepository {
             File iconFile = getVersionIconFile(id);
             if (iconFile.exists())
                 return new Image("file:" + iconFile.getAbsolutePath());
-            else if (LibraryAnalyzer.isModded(this, version))
-                return newImage("/assets/img/furnace.png");
-            else
+            else if (LibraryAnalyzer.isModded(this, version)) {
+                LibraryAnalyzer libraryAnalyzer = LibraryAnalyzer.analyze(version);
+                if (libraryAnalyzer.has(LibraryAnalyzer.LibraryType.FABRIC))
+                    return newImage("/assets/img/fabric.png");
+                else if (libraryAnalyzer.has(LibraryAnalyzer.LibraryType.FORGE))
+                    return newImage("/assets/img/forge.png");
+                else if (libraryAnalyzer.has(LibraryAnalyzer.LibraryType.QUILT))
+                    return newImage("/assets/img/quilt.png");
+                else if (libraryAnalyzer.has(LibraryAnalyzer.LibraryType.OPTIFINE))
+                    return newImage("/assets/img/command.png");
+                else if (libraryAnalyzer.has(LibraryAnalyzer.LibraryType.LITELOADER))
+                    return newImage("/assets/img/chicken.png");
+                else
+                    return newImage("/assets/img/furnace.png");
+            } else
                 return newImage("/assets/img/grass.png");
         } else {
             return newImage(iconType.getResourceUrl());


### PR DESCRIPTION
Close #2337 
目前的逻辑是：
优先考虑 Fabric，Forge，Quilt，如果有三者之一就使用他们的图标；
其次考虑 Optifine，若有则用 Optifine 图标；
其次考虑 LiteLoader，若有则用 LiteLoader 图标；
否则就草方块

**警告：该 PR 引入了新的对 PNG 素材的引用，可能与 #2276 冲突！**