### PR TITLE
Fix #2371 自动升级 Mod 中 Task 总量显示错误

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModCheckUpdatesTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModCheckUpdatesTask.java
@@ -46,7 +46,7 @@ public class ModCheckUpdatesTask extends Task<List<LocalModFile.ModUpdate>> {
                 .collect(Collectors.toList());
 
         setStage("mods.check_updates");
-        getProperties().put("total", dependents.size());
+        getProperties().put("total", dependents.size() * RemoteMod.Type.values().length);
     }
 
     @Override


### PR DESCRIPTION
![image](https://github.com/huanghongxun/HMCL/assets/88144530/429012fd-1c13-4679-91c6-eb039280b0ac)
475/373

原因：373 是总共的 Mod 数，475 是已经完成的 Task 总数（每个 Mod 都会有两个 Task 来更新，一个负责 Curseforge，另一个是 Modrinth）

Fix #2371 