### PR TITLE
Support #2393 添加「不使用启动器提供的 log4j2 配置文件」的快捷选项 

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/game/HMCLGameRepository.java
@@ -373,6 +373,7 @@ public class HMCLGameRepository extends DefaultGameRepository {
                 .setRenderer(vs.getRenderer())
                 .setUseNativeGLFW(vs.isUseNativeGLFW())
                 .setUseNativeOpenAL(vs.isUseNativeOpenAL())
+                .setNoDefaultLog4j2Args(vs.isNoDefaultLog4j2Args())
                 .setDaemon(!makeLaunchScript && vs.getLauncherVisibility().isDaemon())
                 .setJavaAgents(javaAgents);
         if (config().hasProxy()) {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/setting/VersionSetting.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/setting/VersionSetting.java
@@ -609,6 +609,20 @@ public final class VersionSetting implements Cloneable {
         this.useNativeOpenAL.set(useNativeOpenAL);
     }
 
+    private final BooleanProperty noDefaultLog4j2Args = new SimpleBooleanProperty(this, "noDefaultLog4j2Args", false);
+
+    public boolean isNoDefaultLog4j2Args() {
+        return noDefaultLog4j2Args.get();
+    }
+
+    public BooleanProperty noDefaultLog4j2ArgsProperty() {
+        return noDefaultLog4j2Args;
+    }
+
+    public void setNoDefaultLog4j2Args(boolean noDefaultLog4j2Args) {
+        this.noDefaultLog4j2Args.set(noDefaultLog4j2Args);
+    }
+
     private final ObjectProperty<VersionIconType> versionIcon = new SimpleObjectProperty<>(this, "versionIcon", VersionIconType.DEFAULT);
 
     public VersionIconType getVersionIcon() {
@@ -722,6 +736,7 @@ public final class VersionSetting implements Cloneable {
         rendererProperty.addListener(listener);
         useNativeGLFW.addListener(listener);
         useNativeOpenAL.addListener(listener);
+        noDefaultLog4j2Args.addListener(listener);
         launcherVisibilityProperty.addListener(listener);
         defaultJavaPathProperty.addListener(listener);
         nativesDirProperty.addListener(listener);
@@ -761,6 +776,7 @@ public final class VersionSetting implements Cloneable {
         versionSetting.setRenderer(getRenderer());
         versionSetting.setUseNativeGLFW(isUseNativeGLFW());
         versionSetting.setUseNativeOpenAL(isUseNativeOpenAL());
+        versionSetting.setNoDefaultLog4j2Args(isNoDefaultLog4j2Args());
         versionSetting.setLauncherVisibility(getLauncherVisibility());
         versionSetting.setNativesDir(getNativesDir());
         versionSetting.setVersionIcon(getVersionIcon());
@@ -800,6 +816,7 @@ public final class VersionSetting implements Cloneable {
             obj.addProperty("processPriority", src.getProcessPriority().ordinal());
             obj.addProperty("useNativeGLFW", src.isUseNativeGLFW());
             obj.addProperty("useNativeOpenAL", src.isUseNativeOpenAL());
+            obj.addProperty("noDefaultLog4j2Args", src.isNoDefaultLog4j2Args());
             obj.addProperty("gameDirType", src.getGameDirType().ordinal());
             obj.addProperty("defaultJavaPath", src.getDefaultJavaPath());
             obj.addProperty("nativesDir", src.getNativesDir());
@@ -860,6 +877,7 @@ public final class VersionSetting implements Cloneable {
             vs.setProcessPriority(getOrDefault(ProcessPriority.values(), obj.get("processPriority"), ProcessPriority.NORMAL));
             vs.setUseNativeGLFW(Optional.ofNullable(obj.get("useNativeGLFW")).map(JsonElement::getAsBoolean).orElse(false));
             vs.setUseNativeOpenAL(Optional.ofNullable(obj.get("useNativeOpenAL")).map(JsonElement::getAsBoolean).orElse(false));
+            vs.setNoDefaultLog4j2Args(Optional.ofNullable(obj.get("noDefaultLog4j2Args")).map(JsonElement::getAsBoolean).orElse(false));
             vs.setGameDirType(getOrDefault(GameDirectoryType.values(), obj.get("gameDirType"), GameDirectoryType.ROOT_FOLDER));
             vs.setDefaultJavaPath(Optional.ofNullable(obj.get("defaultJavaPath")).map(JsonElement::getAsString).orElse(null));
             vs.setNativesDirType(getOrDefault(NativesDirectoryType.values(), obj.get("nativesDirType"), NativesDirectoryType.VERSION_FOLDER));

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/AdvancedVersionSettingPage.java
@@ -46,6 +46,7 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
     private final OptionToggleButton noNativesPatchPane;
     private final OptionToggleButton useNativeGLFWPane;
     private final OptionToggleButton useNativeOpenALPane;
+    private final OptionToggleButton noDefaultLog4j2Args;
     private final ComponentSublist nativesDirSublist;
     private final MultiFileItem<NativesDirectoryType> nativesDirItem;
     private final MultiFileItem.FileOption<NativesDirectoryType> nativesDirCustomOption;
@@ -194,10 +195,15 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
             useNativeOpenALPane = new OptionToggleButton();
             useNativeOpenALPane.setTitle(i18n("settings.advanced.use_native_openal"));
 
+            noDefaultLog4j2Args = new OptionToggleButton();
+            noDefaultLog4j2Args.setTitle(i18n("settings.advanced.no_default_log4j2_args"));
+
             workaroundPane.getContent().setAll(
                     nativesDirSublist, rendererPane,
                     noJVMArgsPane, noGameCheckPane, noJVMCheckPane, noNativesPatchPane,
-                    useNativeGLFWPane, useNativeOpenALPane);
+                    useNativeGLFWPane, useNativeOpenALPane,
+                    noDefaultLog4j2Args
+            );
         }
 
         rootPane.getChildren().addAll(
@@ -225,6 +231,7 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
         noNativesPatchPane.selectedProperty().bindBidirectional(versionSetting.notPatchNativesProperty());
         useNativeGLFWPane.selectedProperty().bindBidirectional(versionSetting.useNativeGLFWProperty());
         useNativeOpenALPane.selectedProperty().bindBidirectional(versionSetting.useNativeOpenALProperty());
+        noDefaultLog4j2Args.selectedProperty().bindBidirectional(versionSetting.noDefaultLog4j2ArgsProperty());
 
         nativesDirItem.selectedDataProperty().bindBidirectional(versionSetting.nativesDirTypeProperty());
         nativesDirSublist.subtitleProperty().bind(Bindings.createStringBinding(() -> Paths.get(profile.getRepository().getRunDirectory(versionId).getAbsolutePath() + "/natives").normalize().toString(),
@@ -247,6 +254,7 @@ public final class AdvancedVersionSettingPage extends StackPane implements Decor
         noNativesPatchPane.selectedProperty().unbindBidirectional(versionSetting.notPatchNativesProperty());
         useNativeGLFWPane.selectedProperty().unbindBidirectional(versionSetting.useNativeGLFWProperty());
         useNativeOpenALPane.selectedProperty().unbindBidirectional(versionSetting.useNativeOpenALProperty());
+        noDefaultLog4j2Args.selectedProperty().unbindBidirectional(versionSetting.noDefaultLog4j2ArgsProperty());
 
         nativesDirItem.selectedDataProperty().unbindBidirectional(versionSetting.nativesDirTypeProperty());
         nativesDirSublist.subtitleProperty().unbind();

--- a/HMCL/src/main/resources/assets/lang/I18N.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N.properties
@@ -1043,6 +1043,7 @@ settings.advanced.server_ip=Server Address
 settings.advanced.server_ip.prompt=Join automatically after launching the game.
 settings.advanced.use_native_glfw=[Linux Only] Use system GLFW
 settings.advanced.use_native_openal=[Linux Only] Use system OpenAL
+settings.advanced.no_default_log4j2_args=Do not use the Log4j2 configuration file provided by HMCL
 settings.advanced.workaround=Workarounds
 settings.advanced.workaround.warning=Workaround options are intended only for expert users. Tweaking with these options may crash the game. Unless you know what you are doing, please do not modify these options.
 settings.advanced.wrapper_launcher=Wrapper Command

--- a/HMCL/src/main/resources/assets/lang/I18N_zh.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh.properties
@@ -910,6 +910,7 @@ settings.advanced.server_ip=伺服器位址
 settings.advanced.server_ip.prompt=預設，啟動遊戲後直接進入對應伺服器
 settings.advanced.use_native_glfw=使用系統 GLFW
 settings.advanced.use_native_openal=使用系統 OpenAL
+settings.advanced.no_default_log4j2_args=不使用啟動器提供的 Log4j2 配置文件
 settings.advanced.workaround=除錯選項
 settings.advanced.workaround.warning=除錯選項僅提供給專業玩家使用。修改除錯選項可能會導致遊戲無法啟動。除非你知道你在做什麼，否則請不要修改這些選項。
 settings.advanced.wrapper_launcher=前置指令

--- a/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
+++ b/HMCL/src/main/resources/assets/lang/I18N_zh_CN.properties
@@ -910,6 +910,7 @@ settings.advanced.server_ip=服务器地址
 settings.advanced.server_ip.prompt=默认，启动游戏后可以直接进入对应服务器
 settings.advanced.use_native_glfw=使用系统 GLFW
 settings.advanced.use_native_openal=使用系统 OpenAL
+settings.advanced.no_default_log4j2_args=不使用启动器提供的 Log4j2 配置文件
 settings.advanced.workaround=调试选项
 settings.advanced.workaround.warning=调试选项仅提供给专业玩家使用。调试选项可能会导致游戏无法启动。除非你知道你在做什么，否则请不要修改这些选项！
 settings.advanced.wrapper_launcher=包装命令

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/game/LaunchOptions.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/game/LaunchOptions.java
@@ -61,6 +61,7 @@ public class LaunchOptions implements Serializable {
     private Renderer renderer = Renderer.DEFAULT;
     private boolean useNativeGLFW;
     private boolean useNativeOpenAL;
+    private boolean noDefaultLog4j2Args;
     private boolean daemon;
 
     /**
@@ -267,6 +268,10 @@ public class LaunchOptions implements Serializable {
         return useNativeOpenAL;
     }
 
+    public boolean isNoDefaultLog4j2Args() {
+        return noDefaultLog4j2Args;
+    }
+
     /**
      * Will launcher keeps alive after game launched or not.
      */
@@ -459,6 +464,11 @@ public class LaunchOptions implements Serializable {
 
         public Builder setUseNativeOpenAL(boolean useNativeOpenAL) {
             options.useNativeOpenAL = useNativeOpenAL;
+            return this;
+        }
+
+        public Builder setNoDefaultLog4j2Args(boolean noDefaultLog4j2Args) {
+            options.noDefaultLog4j2Args = noDefaultLog4j2Args;
             return this;
         }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java
@@ -152,14 +152,16 @@ public class DefaultLauncher extends Launcher {
         res.addDefault("-Dsun.stdout.encoding=", encoding.name());
         res.addDefault("-Dsun.stderr.encoding=", encoding.name());
 
-        // Fix RCE vulnerability of log4j2
-        res.addDefault("-Djava.rmi.server.useCodebaseOnly=", "true");
-        res.addDefault("-Dcom.sun.jndi.rmi.object.trustURLCodebase=", "false");
-        res.addDefault("-Dcom.sun.jndi.cosnaming.object.trustURLCodebase=", "false");
+        if (!options.isNoDefaultLog4j2Args()) {
+            // Fix RCE vulnerability of log4j2
+            res.addDefault("-Djava.rmi.server.useCodebaseOnly=", "true");
+            res.addDefault("-Dcom.sun.jndi.rmi.object.trustURLCodebase=", "false");
+            res.addDefault("-Dcom.sun.jndi.cosnaming.object.trustURLCodebase=", "false");
 
-        String formatMsgNoLookups = res.addDefault("-Dlog4j2.formatMsgNoLookups=", "true");
-        if (!"-Dlog4j2.formatMsgNoLookups=false".equals(formatMsgNoLookups) && isUsingLog4j()) {
-            res.addDefault("-Dlog4j.configurationFile=", getLog4jConfigurationFile().getAbsolutePath());
+            String formatMsgNoLookups = res.addDefault("-Dlog4j2.formatMsgNoLookups=", "true");
+            if (!"-Dlog4j2.formatMsgNoLookups=false".equals(formatMsgNoLookups) && isUsingLog4j()) {
+                res.addDefault("-Dlog4j.configurationFile=", getLog4jConfigurationFile().getAbsolutePath());
+            }
         }
 
         // Default JVM Args


### PR DESCRIPTION
Close #2393

添加「不使用启动器提供的 log4j2 配置文件」的快捷选项 