### PR TITLE
Support1920 Automatically update HMCL to the latest snapshot version from Github Action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,7 @@ jobs:
         MICROSOFT_AUTH_ID: ${{ secrets.MICROSOFT_AUTH_ID }}
         MICROSOFT_AUTH_SECRET: ${{ secrets.MICROSOFT_AUTH_SECRET }}
         CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
+        HMCL_GITHUB_API_TOKEN: ${{ secrets.HMCL_GITHUB_API_TOKEN }}
     - name: Get short SHA
       run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
     - name: Upload Artifacts

--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -11,8 +11,9 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
-val isOfficial = System.getenv("HMCL_SIGNATURE_KEY") != null
-        || (System.getenv("GITHUB_REPOSITORY_OWNER") == "huanghongxun" && System.getenv("GITHUB_BASE_REF").isNullOrEmpty())
+//val isOfficial = System.getenv("HMCL_SIGNATURE_KEY") != null
+//        || (System.getenv("GITHUB_REPOSITORY_OWNER") == "huanghongxun" && System.getenv("GITHUB_BASE_REF").isNullOrEmpty())
+val isOfficial = true
 
 val buildNumber = System.getenv("BUILD_NUMBER")?.toInt().let { number ->
     val offset = System.getenv("BUILD_NUMBER_OFFSET")?.toInt() ?: 0
@@ -25,11 +26,12 @@ val buildNumber = System.getenv("BUILD_NUMBER")?.toInt().let { number ->
     }
 }
 val versionRoot = System.getenv("VERSION_ROOT") ?: "3.5"
-val versionType = System.getenv("VERSION_TYPE") ?: if (isOfficial) "nightly" else "unofficial"
+val versionType = System.getenv("VERSION_TYPE") ?: if (isOfficial) "dev" else "unofficial"
 
 val microsoftAuthId = System.getenv("MICROSOFT_AUTH_ID") ?: ""
 val microsoftAuthSecret = System.getenv("MICROSOFT_AUTH_SECRET") ?: ""
 val curseForgeApiKey = System.getenv("CURSEFORGE_API_KEY") ?: ""
+val gitHubApiToken = System.getenv("HMCL_GITHUB_API_TOKEN") ?: ""
 
 version = "$versionRoot.$buildNumber"
 
@@ -122,6 +124,7 @@ tasks.getByName<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("sha
             "Microsoft-Auth-Id" to microsoftAuthId,
             "Microsoft-Auth-Secret" to microsoftAuthSecret,
             "CurseForge-Api-Key" to curseForgeApiKey,
+            "GitHub-Api-Token" to gitHubApiToken,
             "Build-Channel" to versionType,
             "Class-Path" to "pack200.jar",
             "Add-Opens" to listOf(

--- a/HMCL/build.gradle.kts
+++ b/HMCL/build.gradle.kts
@@ -11,9 +11,8 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
-//val isOfficial = System.getenv("HMCL_SIGNATURE_KEY") != null
-//        || (System.getenv("GITHUB_REPOSITORY_OWNER") == "huanghongxun" && System.getenv("GITHUB_BASE_REF").isNullOrEmpty())
-val isOfficial = true
+val isOfficial = System.getenv("HMCL_SIGNATURE_KEY") != null
+        || (System.getenv("GITHUB_REPOSITORY_OWNER") == "huanghongxun" && System.getenv("GITHUB_BASE_REF").isNullOrEmpty())
 
 val buildNumber = System.getenv("BUILD_NUMBER")?.toInt().let { number ->
     val offset = System.getenv("BUILD_NUMBER_OFFSET")?.toInt() ?: 0

--- a/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/Metadata.java
@@ -41,6 +41,8 @@ public final class Metadata {
     public static final String CONTACT_URL = "https://docs.hmcl.net/help.html";
     public static final String HELP_URL = "https://hmcl.huangyuhui.net/help";
     public static final String CHANGELOG_URL = "https://docs.hmcl.net/changelog/";
+    public static final String OFFICIAL_REPOSITORY = "huanghongxun/HMCL";
+    public static final String OFFICIAL_BRANCH = "javafx";
     public static final String PUBLISH_URL = "https://www.mcbbs.net/thread-142335-1-1.html";
     public static final String EULA_URL = "https://docs.hmcl.net/eula/hmcl.html";
 

--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/UpgradeDialog.java
@@ -23,13 +23,13 @@ import javafx.concurrent.Worker;
 import javafx.scene.control.Label;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
-import org.jackhuang.hmcl.Metadata;
 import org.jackhuang.hmcl.ui.construct.DialogCloseEvent;
 import org.jackhuang.hmcl.upgrade.RemoteVersion;
+import org.jackhuang.hmcl.upgrade.UpdateChannel;
 
 import java.util.logging.Level;
 
-import static org.jackhuang.hmcl.Metadata.CHANGELOG_URL;
+import static org.jackhuang.hmcl.Metadata.*;
 import static org.jackhuang.hmcl.ui.FXUtils.onEscPressed;
 import static org.jackhuang.hmcl.util.Logging.LOG;
 import static org.jackhuang.hmcl.util.i18n.I18n.i18n;
@@ -41,10 +41,16 @@ public class UpgradeDialog extends JFXDialogLayout {
         }
 
         {
-            String url = CHANGELOG_URL + remoteVersion.getChannel().channelName + ".html#nowchange";
+            String url;
+            if (remoteVersion.getChannel() == UpdateChannel.DEVELOPMENT) {
+                url = String.format("https://github.com/%s/compare/%s...%s", OFFICIAL_REPOSITORY, GITHUB_SHA, OFFICIAL_BRANCH);
+            } else {
+                url = CHANGELOG_URL + remoteVersion.getChannel().channelName + ".html#nowchange";
+            }
+
             try {
                 WebView webView = new WebView();
-                webView.getEngine().setUserDataDirectory(Metadata.HMCL_DIRECTORY.toFile());
+                webView.getEngine().setUserDataDirectory(HMCL_DIRECTORY.toFile());
                 WebEngine engine = webView.getEngine();
                 engine.load(url);
                 engine.getLoadWorker().stateProperty().addListener((observable, oldValue, newValue) -> {

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/GitHubSHAChecker.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/GitHubSHAChecker.java
@@ -1,0 +1,125 @@
+/*
+ * Hello Minecraft! Launcher
+ * Copyright (C) 2021  huangyuhui <huanghongxun2008@126.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.jackhuang.hmcl.upgrade;
+
+import com.google.gson.annotations.SerializedName;
+import org.jackhuang.hmcl.Metadata;
+import org.jackhuang.hmcl.util.io.HttpRequest;
+import org.jackhuang.hmcl.util.io.JarUtils;
+import org.jackhuang.hmcl.util.io.NetworkUtils;
+
+import java.io.IOException;
+
+import static org.jackhuang.hmcl.util.Lang.mapOf;
+import static org.jackhuang.hmcl.util.Pair.pair;
+
+public final class GitHubSHAChecker {
+    private GitHubSHAChecker() {
+    }
+
+    private static class GitHubWorkflowRunLookup {
+        private static class GitHubWorkflowRun {
+            @SerializedName("head_sha")
+            private String sha;
+
+            @SerializedName("id")
+            private long id;
+        }
+
+        @SerializedName("workflow_runs")
+        private GitHubWorkflowRun[] runs;
+    }
+
+    private static class GitHubArtifactsLookup {
+        private static class GitHubArtifact {
+            @SerializedName("url")
+            private String url;
+        }
+
+        @SerializedName("artifacts")
+        private GitHubArtifact[] artifacts;
+    }
+
+    private static final String GITHUB_TOKEN = "Bearer " + JarUtils.getManifestAttribute("GitHub-Api-Token", "");
+
+    private static final String JAVA_CI_WORKFLOW = "gradle.yml";
+
+    private static final String WORKFLOW_LOOKUP_URL = String.format("https://api.github.com/repos/%s/actions/workflows/%s/runs", Metadata.OFFICIAL_REPOSITORY, JAVA_CI_WORKFLOW);
+
+    private static final String ARTIFACTS_LOOKUP_URL = String.format("https://api.github.com/repos/%s/actions/runs/%%d/artifacts", Metadata.OFFICIAL_REPOSITORY);
+    
+    private static Boolean isSelfVerified = null;
+
+    public static boolean isSelfVerified() throws IOException {
+        if (isSelfVerified != null) {
+            return isSelfVerified;
+        }
+
+        for (int page = 1; ; page++) {
+            GitHubWorkflowRunLookup lookup = HttpRequest.GET(WORKFLOW_LOOKUP_URL, pair("branch", Metadata.OFFICIAL_BRANCH), pair("event", "push"), pair("head_sha", Metadata.GITHUB_SHA), pair("page", Integer.toString(page)))
+                    .header("Accept", "application/vnd.github+json")
+                    .authorization(GITHUB_TOKEN)
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .getJson(GitHubWorkflowRunLookup.class);
+
+            if (lookup.runs.length == 0) {
+                isSelfVerified = false;
+                return false;
+            }
+
+            for (GitHubWorkflowRunLookup.GitHubWorkflowRun run : lookup.runs) {
+                if (run.sha.equals(Metadata.GITHUB_SHA)) {
+                    isSelfVerified = true;
+                    return true;
+                }
+            }
+        }
+    }
+
+    public static RemoteVersion getLatestArtifact() throws IOException {
+        GitHubWorkflowRunLookup workflowLookup = HttpRequest.GET(WORKFLOW_LOOKUP_URL, pair("branch", Metadata.OFFICIAL_BRANCH), pair("event", "push"), pair("per_page", "1"))
+                .header("Accept", "application/vnd.github+json")
+                .authorization(GITHUB_TOKEN)
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .getJson(GitHubWorkflowRunLookup.class);
+
+        if (workflowLookup.runs.length == 0) {
+            throw new IOException("Broken workflow.");
+        }
+
+        GitHubArtifactsLookup artifactsLookup = HttpRequest.GET(String.format(ARTIFACTS_LOOKUP_URL, workflowLookup.runs[0].id))
+                .header("Accept", "application/vnd.github+json")
+                .authorization(GITHUB_TOKEN)
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .getJson(GitHubArtifactsLookup.class);
+
+        if (artifactsLookup.artifacts.length != 1) {
+            throw new IOException("Broken artifact.");
+        }
+
+        String[] stableVersionParts = RemoteVersion.fetch(UpdateChannel.STABLE, NetworkUtils.withQuery(Metadata.UPDATE_URL, mapOf(
+                pair("version", Metadata.VERSION),
+                pair("channel", UpdateChannel.STABLE.channelName)))
+        ).getVersion().split("\\.");
+        if (stableVersionParts.length != 3) {
+            throw new IOException("Invalid stable version number");
+        }
+
+        return new RemoteVersion(UpdateChannel.DEVELOPMENT, stableVersionParts[0] + "." + stableVersionParts[1] + "." + "dev-" + workflowLookup.runs[0].sha.substring(0, 7), artifactsLookup.artifacts[0].url + "/zip", RemoteVersion.Type.GitHub_ARTIFACT, null);
+    }
+}

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/HMCLDownloadTask.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/HMCLDownloadTask.java
@@ -19,21 +19,35 @@ package org.jackhuang.hmcl.upgrade;
 
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.util.Pack200Utils;
+import org.jackhuang.hmcl.util.io.IOUtils;
+import org.jackhuang.hmcl.util.io.JarUtils;
 import org.jackhuang.hmcl.util.io.NetworkUtils;
 import org.tukaani.xz.XZInputStream;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 
 class HMCLDownloadTask extends FileDownloadTask {
+    private static final String GITHUB_TOKEN = "Bearer " + JarUtils.getManifestAttribute("GitHub-Api-Token", "");
 
     private RemoteVersion.Type archiveFormat;
 
     public HMCLDownloadTask(RemoteVersion version, Path target) {
         super(NetworkUtils.toURL(version.getUrl()), target.toFile(), version.getIntegrityCheck());
+        if (version.getType() == RemoteVersion.Type.GitHub_ARTIFACT) {
+            this.tweaker = httpURLConnection -> {
+                httpURLConnection.setRequestProperty("Accept", "application/vnd.github+json");
+                httpURLConnection.setRequestProperty("Authorization", GITHUB_TOKEN);
+                httpURLConnection.setRequestProperty("X-GitHub-Api-Version", "2022-11-28");
+            };
+        }
         archiveFormat = version.getType();
     }
 
@@ -54,6 +68,24 @@ class HMCLDownloadTask extends FileDownloadTask {
                             JarOutputStream out = new JarOutputStream(Files.newOutputStream(target))) {
                         Pack200Utils.unpack(in, out);
                     }
+                    break;
+
+                case GitHub_ARTIFACT:
+                    byte[] rawData = null;
+                    try (JarFile jarFile = new JarFile(target.toFile())) {
+                        Enumeration<JarEntry> enumeration = jarFile.entries();
+                        while (enumeration.hasMoreElements()) {
+                            JarEntry jarEntry = enumeration.nextElement();
+                            if (jarEntry.getName().endsWith(".jar")) {
+                                rawData = IOUtils.readFullyAsByteArray(jarFile.getInputStream(jarEntry));
+                                break;
+                            }
+                        }
+                    }
+                    if (rawData == null) {
+                        throw new IOException("Broken artifact from github.");
+                    }
+                    Files.write(target, rawData);
                     break;
 
                 default:

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/RemoteVersion.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/RemoteVersion.java
@@ -91,6 +91,7 @@ public class RemoteVersion {
 
     public enum Type {
         PACK_XZ,
-        JAR
+        JAR,
+        GitHub_ARTIFACT
     }
 }

--- a/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/upgrade/UpdateHandler.java
@@ -110,10 +110,6 @@ public final class UpdateHandler {
 
                 if (success) {
                     try {
-                        if (!IntegrityChecker.isSelfVerified()) {
-                            throw new IOException("Current JAR is not verified");
-                        }
-
                         requestUpdate(downloaded, getCurrentLocation());
                         System.exit(0);
                     } catch (IOException e) {
@@ -138,7 +134,17 @@ public final class UpdateHandler {
         LOG.info("Applying update to " + target);
 
         Path self = getCurrentLocation();
-        IntegrityChecker.requireVerifiedJar(self);
+
+        if (Metadata.isDev()) {
+            if (!GitHubSHAChecker.isSelfVerified()) {
+                throw new IOException("Current JAR is not verified");
+            }
+        } else {
+            if (!IntegrityChecker.isSelfVerified()) {
+                throw new IOException("Current JAR is not verified");
+            }
+        }
+
         ExecutableHeaderHelper.copyWithHeader(self, target);
 
         Optional<Path> newFilename = tryRename(target, Metadata.VERSION);
@@ -156,7 +162,16 @@ public final class UpdateHandler {
     }
 
     private static void requestUpdate(Path updateTo, Path self) throws IOException {
-        IntegrityChecker.requireVerifiedJar(updateTo);
+        if (Metadata.isDev()) {
+            if (!GitHubSHAChecker.isSelfVerified()) {
+                throw new IOException("Current JAR is not verified");
+            }
+        } else {
+            if (!IntegrityChecker.isSelfVerified()) {
+                throw new IOException("Current JAR is not verified");
+            }
+        }
+
         startJava(updateTo, "--apply-to", self.toString());
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FetchTask.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/task/FetchTask.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -47,6 +48,7 @@ public abstract class FetchTask<T> extends Task<T> {
     protected final int retry;
     protected boolean caching;
     protected CacheRepository repository = CacheRepository.getInstance();
+    protected Consumer<HttpURLConnection> tweaker;
 
     public FetchTask(List<URL> urls, int retry) {
         Objects.requireNonNull(urls);
@@ -103,6 +105,9 @@ public abstract class FetchTask<T> extends Task<T> {
                     if (checkETag) repository.injectConnection(conn);
 
                     if (conn instanceof HttpURLConnection) {
+                        if (tweaker != null) {
+                            tweaker.accept((HttpURLConnection) conn);
+                        }
                         conn = NetworkUtils.resolveConnection((HttpURLConnection) conn);
                         int responseCode = ((HttpURLConnection) conn).getResponseCode();
 


### PR DESCRIPTION
Close #1920 

### 功能简介
HMCL 配置界面将在检测到当前为快照版本时，显示更新渠道为“无”（默认）和“快照版”。在勾选“快照版后”，仅快照版本可以更新至最新快照版本，而正式版等仍然和之前一样，无法更新到最新快照版本（也不会有对应的更新渠道）。

### 实现细节
通过一个无任何写权限的 Github Token 和 MENIFEST.MF 中的 Github-SHA 键来判断是否为官方构建并获取 HMCL Github Action 的最新构建结果下载。对于 changelog，则直接通过 Github 自带的 commit compare 页面查看。

虽然中国大陆地区连接 Github 并不稳定，但对于本功能的必要性，我做以下说明：
1. 对于开发人员，我们真的非常需要自动获取最新版本快照版来体验新版本的更新情况，这有利于发现潜在的 Bug。（比如之前无法创建账户的 Bug #2372，就是由于我们没有真正用过快照版本导致的）
2. 对于非开发人员，由于他们不会修改更新渠道为“快照版本”，因此不会有任何问题。

### 任务列表
- [x] 通过 Github Token 自动验证当前 Github-SHA 是否为官方构建，并在是官方构建时自动获取最新版本
- [ ] 修改 HMCL 配置界面，检测到为快照版本时显示不同的 UI
- [ ] 将 Github Token 放入 HMCL Github Action 的 secrets 环境变量中