### PR TITLE
修改 DEFAULT_INDEX_URL

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -28,6 +28,6 @@ public final class Constants {
     }
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
-    public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/"; //https://bmclapidoc.bangbang93.com/#api-Version-Version
-    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/"; //https://github.com/zkitefly/Minecraft.Download-data
+    public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
+    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https://raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https://github.com/zkitefly/Minecraft.Download-data/blob/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https://github.com/zkitefly/Minecraft.Download-data/blob/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https://github.com/zkitefly/Minecraft.Download-data/blob/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https://raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -29,5 +29,5 @@ public final class Constants {
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
     public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https://github.com/zkitefly/Minecraft.Download-data/blob/main/indexes/";
+    public static final String DEFAULT_INDEX_URL = "https://gp.zkitefly.eu.org/https://github.com/zkitefly/Minecraft.Download-data/blob/main/indexes/";
 }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Constants.java
@@ -28,6 +28,6 @@ public final class Constants {
     }
 
     public static final String DEFAULT_LIBRARY_URL = "https://libraries.minecraft.net/";
-    public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/";
-    public static final String DEFAULT_INDEX_URL = "https://launchermeta.mojang.com/mc-staging/assets/legacy/c0fd82e8ce9fbc93119e40d96d5a4e62cfa3f729/";
+    public static final String DEFAULT_VERSION_DOWNLOAD_URL = "https://bmclapi2.bangbang93.com/versions/"; //https://bmclapidoc.bangbang93.com/#api-Version-Version
+    public static final String DEFAULT_INDEX_URL = "https://rgp2.zkitefly.eu.org/https:/raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/"; //https://github.com/zkitefly/Minecraft.Download-data
 }


### PR DESCRIPTION
自己弄了个模仿 https://s3.amazonaws.com/Minecraft.Download/indexes/ 格式的下载源

https://github.com/zkitefly/Minecraft.Download-data

e.g. ：https://gp.zkitefly.eu.org/https://raw.githubusercontent.com/zkitefly/Minecraft.Download-data/main/indexes/1.10.json

此处使用 https://gp.zkitefly.eu.org/ 为 GitHub 加速 （如果不行那我就弄成 GitHub Page 加速吧）

Try fix https://github.com/huanghongxun/HMCL/issues/2417