### PR TITLE
(workflows/gitee.yml) Update `Hub Mirror Action` to 1.3

### DIFF
--- a/.github/workflows/gitee.yml
+++ b/.github/workflows/gitee.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mirror Github to Gitee
-        uses: Yikun/hub-mirror-action@v1.1
+        uses: Yikun/hub-mirror-action@v1.3
         with:
           src: github/huanghongxun
           dst: gitee/huanghongxun


### PR DESCRIPTION
Update `Hub Mirror Action` to 1.3 

[Release note](https://github.com/Yikun/hub-mirror-action/releases/tag/v1.3)

> 升级PyYaml以修复PyYaml安装问题 https://github.com/Yikun/hub-mirror-action/pull/182
> 开启pull_request_target帮助开发者触发CI验证 https://github.com/Yikun/hub-mirror-action/pull/139
> 新增clone_style的说明文档 https://github.com/Yikun/hub-mirror-action/pull/146 感谢@AdoShan
> 新增与repo-list-generator共同使用的文档 https://github.com/Yikun/hub-mirror-action/pull/150 感谢@yi-Xu-0100 

Fix sync to gitee action

`ModuleNotFoundError: No module named 'yaml'`

[show detail](https://github.com/huanghongxun/HMCL/actions/runs/5783970016/job/15673761600)

Signed-off-by: yangyangdaji <1504305527@qq.com>