### PR TITLE
Fix missing null checking.

### DIFF
--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
+++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/versions/ModListPage.java
@@ -188,7 +188,7 @@ public final class ModListPage extends ListPageBase<ModListPageSkin.ModInfoObjec
                             return null;
                         })
                         .whenComplete(Schedulers.javafx(), (result, exception) -> {
-                            if (exception != null) {
+                            if (exception != null || result == null) {
                                 Controllers.dialog("Failed to check updates", "failed", MessageDialogPane.MessageType.ERROR);
                             } else if (result.isEmpty()) {
                                 Controllers.dialog(i18n("mods.check_updates.empty"));


### PR DESCRIPTION
修复启动器崩溃

```
---- Hello Minecraft! Crash Report ----
  Version: 3.5.5
  Time: 2023-09-12 19:48:13
  Thread: Thread[#39,ForkJoinPool.commonPool-worker-2,5,main]

  Content:
    java.lang.NullPointerException: Cannot invoke "java.util.List.isEmpty()" because "result" is null
        at org.jackhuang.hmcl.ui.versions.ModListPage.lambda$checkUpdates$12(ModListPage.java:193)
        at org.jackhuang.hmcl.task.Task.lambda$whenComplete$7(Task.java:753)
        at org.jackhuang.hmcl.task.Task$1.execute(Task.java:714)
        at org.jackhuang.hmcl.task.AsyncTaskExecutor.lambda$executeNormalTask$22(AsyncTaskExecutor.java:245)
        at org.jackhuang.hmcl.util.Lang.lambda$wrap$2(Lang.java:291)
        at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
        at javafx.graphics@19.0.2.1/com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at javafx.graphics@19.0.2.1/com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
        at javafx.graphics@19.0.2.1/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at javafx.graphics@19.0.2.1/com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at javafx.graphics@19.0.2.1/com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
        at java.base/java.lang.Thread.run(Thread.java:1623)


-- System Details --
  Operating System: Windows 10 10.0.19045.2364
  System Architecture: AMD64
  Java Architecture: amd64
  Java Version: 20.0.1, Oracle Corporation
  Java VM Version: Java HotSpot(TM) 64-Bit Server VM (mixed mode, sharing), Oracle Corporation
  JVM Max Memory: 4011851776
  JVM Total Memory: 157286400
  JVM Free Memory: 72513168
```