### PR TITLE
Enhance Logging

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -77,22 +77,30 @@ public final class Logging {
                 break;
             }
 
-            for (int lastIndex = 0;;) {
-                int index = first.indexOf(token, lastIndex);
-                if (index == -1) {
-                    second.append(first, lastIndex, first.length());
-                    break;
-                } else {
-                    second.append(first, lastIndex, index);
-                    second.append("<access token>");
-                    lastIndex = index + token.length();
-                }
-            }
+            filterForbiddenTokenInternal(first, second, token);
+
             StringBuilder tmp = first;
             first = second;
             second = tmp;
+
+            second.setLength(0);
         }
         return first.toString();
+    }
+
+    private static void filterForbiddenTokenInternal(StringBuilder source, StringBuilder target, String token) {
+        int lastIndex = 0;
+        while (true) {
+            int index = source.indexOf(token, lastIndex);
+            if (index == -1) {
+                target.append(source, lastIndex, source.length());
+                break;
+            } else {
+                target.append(source, lastIndex, index);
+                target.append("<access token>");
+                lastIndex = index + token.length();
+            }
+        }
     }
 
     public static void start(Path logFolder) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -76,8 +76,8 @@ public final class Logging {
             if (token == null) {
                 break;
             }
-            int lastIndex = 0;
-            while (true) {
+
+            for (int lastIndex = 0;;) {
                 int index = first.indexOf(token, lastIndex);
                 if (index == -1) {
                     second.append(first, lastIndex, first.length());
@@ -104,6 +104,7 @@ public final class Logging {
         });
 
         DefaultFormatter formatter = new DefaultFormatter();
+
         try {
             if (Files.isRegularFile(logFolder))
                 Files.delete(logFolder);

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -70,7 +70,7 @@ public final class Logging {
         }
 
         // Usually, the access token is longer than "<access token>", therefore, we're able to allocate enough space in advance.
-        StringBuilder first = new StringBuilder(message);
+        StringBuilder first = new StringBuilder(message.length()).append(message);
         StringBuilder second = new StringBuilder(message.length());
         for (String token : accessTokens) {
             if (token == null) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/Logging.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.logging.*;
 
 /**
- * @author huangyuhui
+ * @author huangyuhui, Buring_TNT
  */
 public final class Logging {
     private Logging() {


### PR DESCRIPTION
令用户 HMCL 中微软账户和外置登录账户综合数量为 n，经过测试，当 n = 1 时，可以让 HMCL 每输出一行日志 / 接收到来自 Minecraft 的一行日志提升 2ms 取除 token 的速度，且 n 越大，提升越明显。该 PR 可以有效提升 HMCL 在后台时的 CPU 占用
![image](https://github.com/huanghongxun/HMCL/assets/88144530/f2f1f80e-70e2-438d-8689-b69f110e1bfd)
经过测试，166KB 的日志，1533 行，9 Token（每个约350字符），处理速度由 166ms ->15ms（均有充分预热）