### PR TITLE
Fix #2375 Fix network NPE

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
@@ -22,7 +22,6 @@ import com.google.gson.annotations.SerializedName;
 import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.FileDownloadTask.IntegrityCheck;
-import org.jackhuang.hmcl.util.gson.JsonUtils;
 import org.jackhuang.hmcl.util.io.HttpRequest;
 
 import java.io.IOException;
@@ -112,10 +111,7 @@ public class AuthlibInjectorDownloader implements AuthlibInjectorArtifactProvide
 
     private AuthlibInjectorVersionInfo getLatestArtifactInfo() throws IOException {
         try {
-            return JsonUtils.fromNonNullJson(
-                    HttpRequest.GET(downloadProvider.get().injectURL(LATEST_BUILD_URL)).getString(),
-                    AuthlibInjectorVersionInfo.class
-            );
+            return HttpRequest.GET(downloadProvider.get().injectURL(LATEST_BUILD_URL)).getJson(AuthlibInjectorVersionInfo.class);
         } catch (JsonParseException e) {
             throw new IOException("Malformed response", e);
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorDownloader.java
@@ -23,7 +23,7 @@ import org.jackhuang.hmcl.download.DownloadProvider;
 import org.jackhuang.hmcl.task.FileDownloadTask;
 import org.jackhuang.hmcl.task.FileDownloadTask.IntegrityCheck;
 import org.jackhuang.hmcl.util.gson.JsonUtils;
-import org.jackhuang.hmcl.util.io.NetworkUtils;
+import org.jackhuang.hmcl.util.io.HttpRequest;
 
 import java.io.IOException;
 import java.net.URL;
@@ -102,7 +102,7 @@ public class AuthlibInjectorDownloader implements AuthlibInjectorArtifactProvide
                     Optional.ofNullable(latest.checksums.get("sha256"))
                             .map(checksum -> new IntegrityCheck("SHA-256", checksum))
                             .orElse(null))
-                                    .run();
+                    .run();
         } catch (Exception e) {
             throw new IOException("Failed to download authlib-injector", e);
         }
@@ -113,9 +113,9 @@ public class AuthlibInjectorDownloader implements AuthlibInjectorArtifactProvide
     private AuthlibInjectorVersionInfo getLatestArtifactInfo() throws IOException {
         try {
             return JsonUtils.fromNonNullJson(
-                    NetworkUtils.doGet(
-                            new URL(downloadProvider.get().injectURL(LATEST_BUILD_URL))),
-                    AuthlibInjectorVersionInfo.class);
+                    HttpRequest.GET(downloadProvider.get().injectURL(LATEST_BUILD_URL)).getString(),
+                    AuthlibInjectorVersionInfo.class
+            );
         } catch (JsonParseException e) {
             throw new IOException("Malformed response", e);
         }

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/auth/authlibinjector/AuthlibInjectorServer.java
@@ -17,12 +17,9 @@
  */
 package org.jackhuang.hmcl.auth.authlibinjector;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.jackhuang.hmcl.util.Lang.tryCast;
 import static org.jackhuang.hmcl.util.Logging.LOG;
-import static org.jackhuang.hmcl.util.io.IOUtils.readFullyAsByteArray;
-import static org.jackhuang.hmcl.util.io.IOUtils.readFullyWithoutClosing;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -35,6 +32,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 
 import org.jackhuang.hmcl.auth.yggdrasil.YggdrasilService;
+import org.jackhuang.hmcl.util.io.HttpRequest;
+import org.jackhuang.hmcl.util.io.IOUtils;
 import org.jackhuang.hmcl.util.javafx.ObservableHelper;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,7 +76,7 @@ public class AuthlibInjectorServer implements Observable {
 
             try {
                 AuthlibInjectorServer server = new AuthlibInjectorServer(url);
-                server.refreshMetadata(readFullyWithoutClosing(conn.getInputStream()));
+                server.refreshMetadata(IOUtils.readFullyAsStringWithClosing(conn.getInputStream()));
                 return server;
             } finally {
                 conn.disconnect();
@@ -159,12 +158,11 @@ public class AuthlibInjectorServer implements Observable {
     }
 
     public void refreshMetadata() throws IOException {
-        refreshMetadata(readFullyAsByteArray(new URL(url).openStream()));
+        refreshMetadata(HttpRequest.GET(url).getString());
     }
 
-    private void refreshMetadata(byte[] rawResponse) throws IOException {
+    private void refreshMetadata(String text) throws IOException {
         long timestamp = System.currentTimeMillis();
-        String text = new String(rawResponse, UTF_8);
         try {
             setMetadataResponse(text, timestamp);
         } catch (JsonParseException e) {

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpRequest.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/HttpRequest.java
@@ -29,7 +29,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -218,16 +217,21 @@ public abstract class HttpRequest {
     }
 
     private static String getStringWithRetry(ExceptionalSupplier<String, IOException> supplier, int retryTimes) throws IOException {
-        SocketTimeoutException exception = null;
+        Throwable exception = null;
         for (int i = 0; i < retryTimes; i++) {
             try {
                 return supplier.get();
-            } catch (SocketTimeoutException e) {
+            } catch (Throwable e) {
                 exception = e;
             }
         }
-        if (exception != null)
-            throw exception;
+        if (exception != null) {
+            if (exception instanceof IOException) {
+                throw (IOException) exception;
+            } else {
+                throw new IOException(exception);
+            }
+        }
         throw new IOException("retry 0");
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/util/io/IOUtils.java
@@ -44,6 +44,12 @@ public final class IOUtils {
         return result.toByteArray();
     }
 
+    public static String readFullyAsStringWithClosing(InputStream stream) throws IOException {
+        ByteArrayOutputStream result = new ByteArrayOutputStream(Math.max(stream.available(), 32));
+        copyTo(stream, result);
+        return result.toString("UTF-8");
+    }
+
     /**
      * Read all bytes to a buffer from given input stream, and close the input stream finally.
      *


### PR DESCRIPTION
通过 new URL(url).openStream() 做网络请求时，若代理设置出错，Java 内部会抛出 NPE
使用 HttpRequest.GET 调用已封装好的 new URL(url).openConnection() 即可避免此问题