### PR TITLE
Fix #2629 Duplicated dependent mods

### DIFF
--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/RemoteMod.java
@@ -120,7 +120,7 @@ public class RemoteMod {
 
         private final String id;
 
-        private RemoteMod remoteMod = null;
+        private transient RemoteMod remoteMod = null;
 
         private Dependency(DependencyType type, RemoteModRepository remoteModRepository, String modid) {
             this.type = type;
@@ -164,6 +164,26 @@ public class RemoteMod {
                 }
             }
             return this.remoteMod;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Dependency that = (Dependency) o;
+
+            if (type != that.type) return false;
+            if (!remoteModRepository.equals(that.remoteModRepository)) return false;
+            return id.equals(that.id);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = type.hashCode();
+            result = 31 * result + remoteModRepository.hashCode();
+            result = 31 * result + id.hashCode();
+            return result;
         }
     }
 

--- a/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
+++ b/HMCLCore/src/main/java/org/jackhuang/hmcl/mod/curse/CurseAddon.java
@@ -582,7 +582,7 @@ public class CurseAddon implements RemoteMod.IMod {
                             throw new IllegalStateException("Broken datas.");
                         }
                         return RemoteMod.Dependency.ofGeneral(RELATION_TYPE.get(dependency.getRelationType()), CurseForgeRemoteModRepository.MODS, Integer.toString(dependency.getModId()));
-                    }).filter(Objects::nonNull).collect(Collectors.toList()),
+                    }).distinct().filter(Objects::nonNull).collect(Collectors.toList()),
                     gameVersions.stream().filter(ver -> ver.startsWith("1.") || ver.contains("w")).collect(Collectors.toList()),
                     gameVersions.stream().flatMap(version -> {
                         if ("fabric".equalsIgnoreCase(version)) return Stream.of(ModLoaderType.FABRIC);


### PR DESCRIPTION
The return value of the dependent mods may be duplicated from CurseForge API.
Fix #2629